### PR TITLE
fix: fish shell

### DIFF
--- a/src/serverSetup.ts
+++ b/src/serverSetup.ts
@@ -53,8 +53,11 @@ export async function installCodeServer(conn: SSHConnection, serverDownloadUrlTe
         serverDownloadUrlTemplate,
     });
 
+    const installDir = `$HOME/${vscodeServerConfig.serverDataFolderName}/install`;
+    const installScript = `${installDir}/${vscodeServerConfig.commit}.sh`
+
     logger.trace('Server install command:', installServerScript);
-    const commandOutput = await conn.exec(`bash << 'EOF'\n${installServerScript}\nEOF`);
+    const commandOutput = await conn.exec(`mkdir -p ${installDir} && echo '\n${installServerScript.replace(/'/g, '\'"\'"\'')}\n' >${installScript} && bash ${installScript}`);
     if (commandOutput.stderr) {
         logger.trace('Server install command stderr:', commandOutput.stderr);
     }

--- a/src/serverSetup.ts
+++ b/src/serverSetup.ts
@@ -53,11 +53,10 @@ export async function installCodeServer(conn: SSHConnection, serverDownloadUrlTe
         serverDownloadUrlTemplate,
     });
 
-    const installDir = `$HOME/${vscodeServerConfig.serverDataFolderName}/install`;
-    const installScript = `${installDir}/${vscodeServerConfig.commit}.sh`
-
     logger.trace('Server install command:', installServerScript);
-    const commandOutput = await conn.exec(`mkdir -p ${installDir} && echo '\n${installServerScript.replace(/'/g, '\'"\'"\'')}\n' >${installScript} && bash ${installScript}`);
+    // Fish shell does not support heredoc so let's workaround it using -c option,
+    // also replace single quotes (') within the script with ('\'') as there's no quoting within single quotes, see https://unix.stackexchange.com/a/24676
+    const commandOutput = await conn.exec(`bash -c '${installServerScript.replace(/'/g, `'\\''`)}'`);
     if (commandOutput.stderr) {
         logger.trace('Server install command stderr:', commandOutput.stderr);
     }


### PR DESCRIPTION
This PR is replacing the here-document syntax with an install file due to fish shell not supporting the here-document syntax...

I've tested it on linux/fish and macOS.

resolves: #7 