### PR TITLE
fix(windows): support additional shells and remove `uname` dependency

### DIFF
--- a/src/serverSetup.ts
+++ b/src/serverSetup.ts
@@ -90,8 +90,9 @@ export async function installCodeServer(conn: SSHConnection, serverDownloadUrlTe
         const installDir = `$HOME\\${vscodeServerConfig.serverDataFolderName}\\install`;
         const installScript = `${installDir}\\${vscodeServerConfig.commit}.ps1`;
         const endRegex = new RegExp(`${scriptId}: end`);
+        // investigate if it's possible to use `-EncodedCommand` flag
+        // https://devblogs.microsoft.com/powershell/invoking-powershell-with-complex-expressions-using-scriptblocks/
         let command = '';
-
         if (shell === 'powershell') {
             command = `md -Force ${installDir}; echo @'\n${installServerScript}\n'@ | Set-Content ${installScript}; powershell -ExecutionPolicy ByPass -File "${installScript}"`;
         } else if (shell === 'bash') {

--- a/src/serverSetup.ts
+++ b/src/serverSetup.ts
@@ -42,8 +42,7 @@ export async function installCodeServer(conn: SSHConnection, serverDownloadUrlTe
             if (/MINGW64|windows32/g.test(result.stdout)) {
                 platform = 'windows';
             }
-        }
-        else if (result.stderr) {
+        } else if (result.stderr) {
             if (result.stderr.includes('FullyQualifiedErrorId : CommandNotFoundException')) {
                 platform = 'windows';
             }


### PR DESCRIPTION
This PR does for windows server:
- add the support for `cmd` and `bash` (from Git for Windows) shells
- remove the dependency for `uname`