### PR TITLE
feat: get download url from editor

### DIFF
--- a/src/authResolver.ts
+++ b/src/authResolver.ts
@@ -47,6 +47,18 @@ interface SSHKey {
     isPrivate?: boolean;
 }
 
+async function resolveUrlTemplate(): Promise<string> {
+    let url = null;
+
+    const commands = await vscode.commands.getCommands();
+
+    if (commands.some((command) => command === 'remote.serverDownloadUrlTemplate')) {
+        url = await vscode.commands.executeCommand<string | null>('remote.serverDownloadUrlTemplate');
+    }
+
+    return url || 'https://github.com/VSCodium/vscodium/releases/download/${version}.${release}/vscodium-reh-${os}-${arch}-${version}.${release}.tar.gz';
+}
+
 export class RemoteSSHResolver implements vscode.RemoteAuthorityResolver, vscode.Disposable {
 
     private proxyConnections: SSHConnection[] = [];
@@ -80,8 +92,7 @@ export class RemoteSSHResolver implements vscode.RemoteAuthorityResolver, vscode
         const remoteSSHconfig = vscode.workspace.getConfiguration('remote.SSH');
         const enableDynamicForwarding = remoteSSHconfig.get<boolean>('enableDynamicForwarding', true)!;
         const enableAgentForwarding = remoteSSHconfig.get<boolean>('enableAgentForwarding', true)!;
-        const defaultTemplate = await vscode.commands.executeCommand<string>('remote.serverDownloadUrlTemplate');
-        const serverDownloadUrlTemplate = remoteSSHconfig.get<string>('serverDownloadUrlTemplate', defaultTemplate ?? 'https://github.com/VSCodium/vscodium/releases/download/${version}.${release}/vscodium-reh-${os}-${arch}-${version}.${release}.tar.gz')!;
+        const serverDownloadUrlTemplate = remoteSSHconfig.get<string>('serverDownloadUrlTemplate', await resolveUrlTemplate())!;
         const defaultExtensions = remoteSSHconfig.get<string[]>('defaultExtensions', []);
         const remotePlatformMap = remoteSSHconfig.get<Record<string, string>>('remotePlatform', {});
         const remoteServerListenOnSocket = remoteSSHconfig.get<boolean>('remoteServerListenOnSocket', false)!;

--- a/src/authResolver.ts
+++ b/src/authResolver.ts
@@ -65,7 +65,7 @@ export class RemoteSSHResolver implements vscode.RemoteAuthorityResolver, vscode
     ) {
     }
 
-    resolve(authority: string, context: vscode.RemoteAuthorityResolverContext): Thenable<vscode.ResolverResult> {
+    async resolve(authority: string, context: vscode.RemoteAuthorityResolverContext): Promise<vscode.ResolverResult> {
         const [type, dest] = authority.split('+');
         if (type !== REMOTE_SSH_AUTHORITY) {
             throw new Error(`Invalid authority type for SSH resolver: ${type}`);
@@ -80,7 +80,8 @@ export class RemoteSSHResolver implements vscode.RemoteAuthorityResolver, vscode
         const remoteSSHconfig = vscode.workspace.getConfiguration('remote.SSH');
         const enableDynamicForwarding = remoteSSHconfig.get<boolean>('enableDynamicForwarding', true)!;
         const enableAgentForwarding = remoteSSHconfig.get<boolean>('enableAgentForwarding', true)!;
-        const serverDownloadUrlTemplate = remoteSSHconfig.get<string>('serverDownloadUrlTemplate', 'https://github.com/VSCodium/vscodium/releases/download/${version}.${release}/vscodium-reh-${os}-${arch}-${version}.${release}.tar.gz')!;
+        const defaultTemplate = await vscode.commands.executeCommand<string>('remote.serverDownloadUrlTemplate');
+        const serverDownloadUrlTemplate = remoteSSHconfig.get<string>('serverDownloadUrlTemplate', defaultTemplate ?? 'https://github.com/VSCodium/vscodium/releases/download/${version}.${release}/vscodium-reh-${os}-${arch}-${version}.${release}.tar.gz')!;
         const defaultExtensions = remoteSSHconfig.get<string[]>('defaultExtensions', []);
         const remotePlatformMap = remoteSSHconfig.get<Record<string, string>>('remotePlatform', {});
         const remoteServerListenOnSocket = remoteSSHconfig.get<boolean>('remoteServerListenOnSocket', false)!;

--- a/src/serverSetup.ts
+++ b/src/serverSetup.ts
@@ -71,7 +71,7 @@ export async function installCodeServer(conn: SSHConnection, serverDownloadUrlTe
 
     let commandOutput: { stdout: string; stderr: string };
     if (platform === 'windows') {
-         const installServerScript = generatePowerShellInstallScript({
+        const installServerScript = generatePowerShellInstallScript({
             id: scriptId,
             version: vscodeServerConfig.version,
             commit: vscodeServerConfig.commit,
@@ -407,7 +407,7 @@ function generatePowerShellInstallScript({ id, quality, version, commit, release
         .replace(/\$\{version\}/g, version)
         .replace(/\$\{commit\}/g, commit)
         .replace(/\$\{os\}/g, 'win32')
-        .replace(/\$\{arch\}/g,  'x64')
+        .replace(/\$\{arch\}/g, 'x64')
         .replace(/\$\{release\}/g, release ?? '');
 
     return `
@@ -485,13 +485,13 @@ if(!(Test-Path $SERVER_SCRIPT)) {
     del vscode-server.tar.gz
 
     $REQUEST_ARGUMENTS = @{
-		Uri="${downloadUrl}"
-		TimeoutSec=20
-		OutFile="vscode-server.tar.gz"
-		UseBasicParsing=$True
-	}
+        Uri="${downloadUrl}"
+        TimeoutSec=20
+        OutFile="vscode-server.tar.gz"
+        UseBasicParsing=$True
+    }
 
-	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 
     Invoke-RestMethod @REQUEST_ARGUMENTS
 


### PR DESCRIPTION
This PR is proposal on how to manage #37 and add support for other editors other than VSCodium.

For that, I would like to add the command `remote.serverDownloadUrlTemplate` which would return the url template to download the server archive. I will add it to VSCodium with a new patch. 

@jeanp413 @GitMensch What do you think?