### PR TITLE
fix: don't limit to download url command to only VSCodium

### DIFF
--- a/src/authResolver.ts
+++ b/src/authResolver.ts
@@ -47,24 +47,6 @@ interface SSHKey {
     isPrivate?: boolean;
 }
 
-// Custom logic to get the serverDownloadUrlTemplate for distros other than vscodium stable
-// Cases:
-// - VSCodium: Added a custom command `remote.serverDownloadUrlTemplate` https://github.com/VSCodium/vscodium/pull/1392
-async function resolveCustomUrlTemplate(): Promise<string | undefined> {
-    let url = undefined;
-    try {
-        // Check if command is registered first, because we execute the command while resolving the remote
-        // it will hangout indefinetely instead of just throwing an error if the command is not present.
-        const commands = await vscode.commands.getCommands();
-        if (commands.some((command) => command === 'remote.serverDownloadUrlTemplate')) {
-            url = await vscode.commands.executeCommand<string>('remote.serverDownloadUrlTemplate');
-        }
-    } catch {
-        // noop
-    }
-    return url;
-}
-
 export class RemoteSSHResolver implements vscode.RemoteAuthorityResolver, vscode.Disposable {
 
     private proxyConnections: SSHConnection[] = [];
@@ -98,7 +80,7 @@ export class RemoteSSHResolver implements vscode.RemoteAuthorityResolver, vscode
         const remoteSSHconfig = vscode.workspace.getConfiguration('remote.SSH');
         const enableDynamicForwarding = remoteSSHconfig.get<boolean>('enableDynamicForwarding', true)!;
         const enableAgentForwarding = remoteSSHconfig.get<boolean>('enableAgentForwarding', true)!;
-        let serverDownloadUrlTemplate = remoteSSHconfig.get<string>('serverDownloadUrlTemplate', 'https://github.com/VSCodium/vscodium/releases/download/${version}.${release}/vscodium-reh-${os}-${arch}-${version}.${release}.tar.gz')!;
+        const serverDownloadUrlTemplate = remoteSSHconfig.get<string>('serverDownloadUrlTemplate');
         const defaultExtensions = remoteSSHconfig.get<string[]>('defaultExtensions', []);
         const remotePlatformMap = remoteSSHconfig.get<Record<string, string>>('remotePlatform', {});
         const remoteServerListenOnSocket = remoteSSHconfig.get<boolean>('remoteServerListenOnSocket', false)!;
@@ -197,8 +179,6 @@ export class RemoteSSHResolver implements vscode.RemoteAuthorityResolver, vscode
                 if (agentForward) {
                     envVariables.push('SSH_AUTH_SOCK');
                 }
-
-                serverDownloadUrlTemplate = await resolveCustomUrlTemplate() || serverDownloadUrlTemplate;
 
                 const installResult = await installCodeServer(this.sshConnection, serverDownloadUrlTemplate, defaultExtensions, envVariables, remotePlatformMap[sshDest.hostname], remoteServerListenOnSocket, this.logger);
 

--- a/src/authResolver.ts
+++ b/src/authResolver.ts
@@ -53,13 +53,11 @@ interface SSHKey {
 async function resolveCustomUrlTemplate(): Promise<string | undefined> {
     let url = undefined;
     try {
-        if (vscode.env.appName.toLowerCase().includes('vscodium')) {
-            // Check if command is registered first, because we execute the command while resolving the remote
-            // it will hangout indefinetely instead of just throwing an error if the command is not present.
-            const commands = await vscode.commands.getCommands();
-            if (commands.some((command) => command === 'remote.serverDownloadUrlTemplate')) {
-                url = await vscode.commands.executeCommand<string>('remote.serverDownloadUrlTemplate');
-            }
+        // Check if command is registered first, because we execute the command while resolving the remote
+        // it will hangout indefinetely instead of just throwing an error if the command is not present.
+        const commands = await vscode.commands.getCommands();
+        if (commands.some((command) => command === 'remote.serverDownloadUrlTemplate')) {
+            url = await vscode.commands.executeCommand<string>('remote.serverDownloadUrlTemplate');
         }
     } catch {
         // noop

--- a/src/serverConfig.ts
+++ b/src/serverConfig.ts
@@ -12,35 +12,26 @@ async function getVSCodeProductJson() {
     return vscodeProductJson;
 }
 
-let vscodePackageJson: any;
-async function getVSCodePackageJson() {
-    if (!vscodePackageJson) {
-        const packageJsonStr = await fs.promises.readFile(path.join(vscode.env.appRoot, 'package.json'), 'utf8');
-        vscodePackageJson = JSON.parse(packageJsonStr);
-    }
-
-    return vscodePackageJson;
-}
-
 export interface IServerConfig {
     version: string;
     commit: string;
     quality: string;
-    release?: string; // vscodium specific
+    release?: string; // vscodium-like specific
     serverApplicationName: string;
     serverDataFolderName: string;
+    serverDownloadUrlTemplate?: string; // vscodium-like specific
 }
 
 export async function getVSCodeServerConfig(): Promise<IServerConfig> {
     const productJson = await getVSCodeProductJson();
-    const packageJson = await getVSCodePackageJson();
 
     return {
         version: vscode.version.replace('-insider',''),
         commit: productJson.commit,
         quality: productJson.quality,
-        release: packageJson.release,
+        release: productJson.release,
         serverApplicationName: productJson.serverApplicationName,
-        serverDataFolderName: productJson.serverDataFolderName
+        serverDataFolderName: productJson.serverDataFolderName,
+        serverDownloadUrlTemplate: productJson.serverDownloadUrlTemplate
     };
 }

--- a/src/serverSetup.ts
+++ b/src/serverSetup.ts
@@ -35,7 +35,9 @@ export class ServerInstallError extends Error {
     }
 }
 
-export async function installCodeServer(conn: SSHConnection, serverDownloadUrlTemplate: string, extensionIds: string[], envVariables: string[], platform: string | undefined, useSocketPath: boolean, logger: Log): Promise<ServerInstallResult> {
+const DEFAULT_DOWNLOAD_URL_TEMPLATE = 'https://github.com/VSCodium/vscodium/releases/download/${version}.${release}/vscodium-reh-${os}-${arch}-${version}.${release}.tar.gz';
+
+export async function installCodeServer(conn: SSHConnection, serverDownloadUrlTemplate: string | undefined, extensionIds: string[], envVariables: string[], platform: string | undefined, useSocketPath: boolean, logger: Log): Promise<ServerInstallResult> {
     let shell = 'powershell';
 
     // detect plaform and shell for windows
@@ -82,7 +84,7 @@ export async function installCodeServer(conn: SSHConnection, serverDownloadUrlTe
             useSocketPath,
             serverApplicationName: vscodeServerConfig.serverApplicationName,
             serverDataFolderName: vscodeServerConfig.serverDataFolderName,
-            serverDownloadUrlTemplate,
+            serverDownloadUrlTemplate: serverDownloadUrlTemplate ?? vscodeServerConfig.serverDownloadUrlTemplate ?? DEFAULT_DOWNLOAD_URL_TEMPLATE,
         });
 
         logger.trace('Server install command:', installServerScript);
@@ -138,7 +140,7 @@ export async function installCodeServer(conn: SSHConnection, serverDownloadUrlTe
             useSocketPath,
             serverApplicationName: vscodeServerConfig.serverApplicationName,
             serverDataFolderName: vscodeServerConfig.serverDataFolderName,
-            serverDownloadUrlTemplate,
+            serverDownloadUrlTemplate: serverDownloadUrlTemplate ?? vscodeServerConfig.serverDownloadUrlTemplate ?? DEFAULT_DOWNLOAD_URL_TEMPLATE,
         });
 
         logger.trace('Server install command:', installServerScript);


### PR DESCRIPTION
This PR removes the limit the usefulness of the command so it can be used by any editor.
For example, my editor [MrCode](https://github.com/zokugun/MrCode) which is based on VSCodium...