### PR TITLE
Add support for (unofficial) FreeBSD REH

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ You can connect to a running SSH server on the following platforms.
 - ARMv8l (AArch64) Ubuntu 18.04+ (64-bit).
 - macOS 10.14+ (Mojave)
 - Windows 10+
+- FreeBSD 13 (Requires manual remote-extension-host installation)
 
 ## Requirements
 

--- a/src/serverSetup.ts
+++ b/src/serverSetup.ts
@@ -252,6 +252,9 @@ case $PLATFORM in
     Linux)
         SERVER_OS="linux"
         ;;
+    FreeBSD)
+        SERVER_OS="freebsd"
+        ;;
     *)
         echo "Error platform not supported: $PLATFORM"
         print_install_results_and_exit 1
@@ -261,7 +264,7 @@ esac
 # Check machine architecture
 ARCH="$(uname -m)"
 case $ARCH in
-    x86_64)
+    x86_64 | amd64)
         SERVER_ARCH="x64"
         ;;
     armv7l | armv8l)
@@ -298,6 +301,11 @@ SERVER_DOWNLOAD_URL="$(echo "${serverDownloadUrlTemplate.replace(/\$\{/g, '\\${'
 
 # Check if server script is already installed
 if [[ ! -f $SERVER_SCRIPT ]]; then
+    if [[ "$SERVER_OS" = "freebsd" ]]; then
+        echo "Error FreeBSD needs manual installation of remote extension host"
+        print_install_results_and_exit 1
+    fi
+
     pushd $SERVER_DIR > /dev/null
 
     if [[ ! -z $(which wget) ]]; then


### PR DESCRIPTION
While FreeBSD is not officially supported by vscode, it is possible to connect REH with some modifications.

FYI, the steps are described at https://github.com/openingnow/freebsd-vscode-reh.