### PR TITLE
Fix adapt for server with both `curl` and `busybox version wget`

### DIFF
--- a/src/serverSetup.ts
+++ b/src/serverSetup.ts
@@ -310,10 +310,10 @@ if [[ ! -f $SERVER_SCRIPT ]]; then
 
     pushd $SERVER_DIR > /dev/null
 
-    if [[ ! -z $(which wget) ]]; then
-        wget --tries=3 --timeout=10 --quiet -O vscode-server.tar.gz $SERVER_DOWNLOAD_URL
-    elif [[ ! -z $(which curl) ]]; then
+    if [[ ! -z $(which curl) ]]; then
         curl --retry 3 --connect-timeout 10 --location --silent --output vscode-server.tar.gz $SERVER_DOWNLOAD_URL
+    elif [[ ! -z $(which wget) ]]; then
+        wget --tries=3 --timeout=10 --quiet -O vscode-server.tar.gz $SERVER_DOWNLOAD_URL
     else
         echo "Error no tool to download server binary"
         print_install_results_and_exit 1


### PR DESCRIPTION
NOTE: In my trial last week, it was reported that a parameter (I forgotten ...) in the wget command was not supported by the busybox version wget, and I just temporarily renamed the wget on that server ...