### PR TITLE
adding %r username replacement to proxycommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.0.33
+
+- feat: support %r user substitution in proxycommand
 ## 0.0.32
 
 - feat: use serverDownloadUrlTemplate from product.json (#59) 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "open-remote-ssh",
 	"displayName": "Open Remote - SSH",
 	"description": "Use any remote machine with a SSH server as your development environment.",
-	"version": "0.0.32",
+	"version": "0.0.33",
 	"publisher": "jeanp413",
 	"repository": {
 		"type": "git",

--- a/src/authResolver.ts
+++ b/src/authResolver.ts
@@ -149,7 +149,7 @@ export class RemoteSSHResolver implements vscode.RemoteAuthorityResolver, vscode
                     }
                 } else if (sshHostConfig['ProxyCommand']) {
                     const proxyArgs = (sshHostConfig['ProxyCommand'] as unknown as string[])
-                        .map((arg) => arg.replace('%h', sshHostName).replace('%p', sshPort.toString()));
+                        .map((arg) => arg.replace('%h', sshHostName).replace('%p', sshPort.toString()).replace('%r', sshUser));
                     const proxyCommand = proxyArgs.shift()!;
 
                     this.logger.trace(`Spawning ProxyCommand: ${proxyCommand} ${proxyArgs.join(' ')}`);


### PR DESCRIPTION
ProxyCommand can include a %r as a standin for the username, adding a line to support this

My proxy setup uses this and doesn't work without it. On hosts without the proxy it all works, thanks for your effort!