### PR TITLE
Enable remote support for ppc64le

### DIFF
--- a/src/serverSetup.ts
+++ b/src/serverSetup.ts
@@ -278,6 +278,9 @@ case $ARCH in
     arm64 | aarch64)
         SERVER_ARCH="arm64"
         ;;
+    ppc64le)
+        SERVER_ARCH="ppc64le"
+        ;;
     *)
         echo "Error architecture not supported: $ARCH"
         print_install_results_and_exit 1


### PR DESCRIPTION
Enable open-remote-ssh to lookup for VSCodium binaries if the remote host is running ppc64le.