### PR TITLE
Add PreferredAuthentications support

### DIFF
--- a/src/authResolver.ts
+++ b/src/authResolver.ts
@@ -104,6 +104,8 @@ export class RemoteSSHResolver implements vscode.RemoteAuthorityResolver, vscode
                 const agentForward = enableAgentForwarding && (sshHostConfig['ForwardAgent'] || 'no').toLowerCase() === 'yes';
                 const agent = agentForward && this.sshAgentSock ? new ssh2.OpenSSHAgent(this.sshAgentSock) : undefined;
 
+                const preferredAuthentications = sshHostConfig['PreferredAuthentications'] ? sshHostConfig['PreferredAuthentications'].split(',') : ['publickey', 'password', 'keyboard-interactive'];
+                
                 const identityFiles: string[] = (sshHostConfig['IdentityFile'] as unknown as string[]) || [];
                 const identitiesOnly = (sshHostConfig['IdentitiesOnly'] || 'no').toLowerCase() === 'yes';
                 const identityKeys = await gatherIdentityFiles(identityFiles, this.sshAgentSock, identitiesOnly, this.logger);
@@ -130,7 +132,7 @@ export class RemoteSSHResolver implements vscode.RemoteAuthorityResolver, vscode
                         const proxyIdentitiesOnly = (proxyHostConfig['IdentitiesOnly'] || 'no').toLowerCase() === 'yes';
                         const proxyIdentityKeys = await gatherIdentityFiles(proxyIdentityFiles, this.sshAgentSock, proxyIdentitiesOnly, this.logger);
 
-                        const proxyAuthHandler = this.getSSHAuthHandler(proxyUser, proxyhHostName, proxyIdentityKeys);
+                        const proxyAuthHandler = this.getSSHAuthHandler(proxyUser, proxyhHostName, proxyIdentityKeys, preferredAuthentications);
                         const proxyConnection = new SSHConnection({
                             host: !proxyStream ? proxyhHostName : undefined,
                             port: !proxyStream ? proxyPort : undefined,
@@ -162,7 +164,7 @@ export class RemoteSSHResolver implements vscode.RemoteAuthorityResolver, vscode
                 }
 
                 // Create final shh connection
-                const sshAuthHandler = this.getSSHAuthHandler(sshUser, sshHostName, identityKeys);
+                const sshAuthHandler = this.getSSHAuthHandler(sshUser, sshHostName, identityKeys, preferredAuthentications);
 
                 this.sshConnection = new SSHConnection({
                     host: !proxyStream ? sshHostName : undefined,
@@ -306,7 +308,7 @@ export class RemoteSSHResolver implements vscode.RemoteAuthorityResolver, vscode
         return new TunnelInfo(localPort, remotePortOrSocketPath, disposables);
     }
 
-    private getSSHAuthHandler(sshUser: string, sshHostName: string, identityKeys: SSHKey[]) {
+    private getSSHAuthHandler(sshUser: string, sshHostName: string, identityKeys: SSHKey[], preferredauthentications: string[]) {
         let passwordRetryCount = PASSWORD_RETRY_COUNT;
         let keyboardRetryCount = PASSWORD_RETRY_COUNT;
         identityKeys = identityKeys.slice();
@@ -319,7 +321,7 @@ export class RemoteSSHResolver implements vscode.RemoteAuthorityResolver, vscode
                     username: sshUser,
                 });
             }
-            if (methodsLeft.includes('publickey') && identityKeys.length) {
+            if (methodsLeft.includes('publickey') && identityKeys.length && preferredauthentications.includes('publickey')) {
                 const identityKey = identityKeys.shift()!;
 
                 this.logger.info(`Trying publickey authentication: ${identityKey.filename} ${identityKey.parsedKey.type} SHA256:${identityKey.fingerprint}`);
@@ -377,7 +379,7 @@ export class RemoteSSHResolver implements vscode.RemoteAuthorityResolver, vscode
                     key
                 });
             }
-            if (methodsLeft.includes('password') && passwordRetryCount > 0) {
+            if (methodsLeft.includes('password') && passwordRetryCount > 0 && preferredauthentications.includes('password')) {
                 if (passwordRetryCount === PASSWORD_RETRY_COUNT) {
                     this.logger.info(`Trying password authentication`);
                 }
@@ -397,7 +399,7 @@ export class RemoteSSHResolver implements vscode.RemoteAuthorityResolver, vscode
                     }
                     : false);
             }
-            if (methodsLeft.includes('keyboard-interactive') && keyboardRetryCount > 0) {
+            if (methodsLeft.includes('keyboard-interactive') && keyboardRetryCount > 0 && preferredauthentications.includes('keyboard-interactive')) {
                 if (keyboardRetryCount === PASSWORD_RETRY_COUNT) {
                     this.logger.info(`Trying keyboard-interactive authentication`);
                 }

--- a/src/authResolver.ts
+++ b/src/authResolver.ts
@@ -308,7 +308,7 @@ export class RemoteSSHResolver implements vscode.RemoteAuthorityResolver, vscode
         return new TunnelInfo(localPort, remotePortOrSocketPath, disposables);
     }
 
-    private getSSHAuthHandler(sshUser: string, sshHostName: string, identityKeys: SSHKey[], preferredauthentications: string[]) {
+    private getSSHAuthHandler(sshUser: string, sshHostName: string, identityKeys: SSHKey[], preferredAuthentications: string[]) {
         let passwordRetryCount = PASSWORD_RETRY_COUNT;
         let keyboardRetryCount = PASSWORD_RETRY_COUNT;
         identityKeys = identityKeys.slice();
@@ -321,7 +321,7 @@ export class RemoteSSHResolver implements vscode.RemoteAuthorityResolver, vscode
                     username: sshUser,
                 });
             }
-            if (methodsLeft.includes('publickey') && identityKeys.length && preferredauthentications.includes('publickey')) {
+            if (methodsLeft.includes('publickey') && identityKeys.length && preferredAuthentications.includes('publickey')) {
                 const identityKey = identityKeys.shift()!;
 
                 this.logger.info(`Trying publickey authentication: ${identityKey.filename} ${identityKey.parsedKey.type} SHA256:${identityKey.fingerprint}`);
@@ -379,7 +379,7 @@ export class RemoteSSHResolver implements vscode.RemoteAuthorityResolver, vscode
                     key
                 });
             }
-            if (methodsLeft.includes('password') && passwordRetryCount > 0 && preferredauthentications.includes('password')) {
+            if (methodsLeft.includes('password') && passwordRetryCount > 0 && preferredAuthentications.includes('password')) {
                 if (passwordRetryCount === PASSWORD_RETRY_COUNT) {
                     this.logger.info(`Trying password authentication`);
                 }
@@ -399,7 +399,7 @@ export class RemoteSSHResolver implements vscode.RemoteAuthorityResolver, vscode
                     }
                     : false);
             }
-            if (methodsLeft.includes('keyboard-interactive') && keyboardRetryCount > 0 && preferredauthentications.includes('keyboard-interactive')) {
+            if (methodsLeft.includes('keyboard-interactive') && keyboardRetryCount > 0 && preferredAuthentications.includes('keyboard-interactive')) {
                 if (keyboardRetryCount === PASSWORD_RETRY_COUNT) {
                     this.logger.info(`Trying keyboard-interactive authentication`);
                 }

--- a/src/authResolver.ts
+++ b/src/authResolver.ts
@@ -104,8 +104,8 @@ export class RemoteSSHResolver implements vscode.RemoteAuthorityResolver, vscode
                 const agentForward = enableAgentForwarding && (sshHostConfig['ForwardAgent'] || 'no').toLowerCase() === 'yes';
                 const agent = agentForward && this.sshAgentSock ? new ssh2.OpenSSHAgent(this.sshAgentSock) : undefined;
 
-                const preferredAuthentications = sshHostConfig['PreferredAuthentications'] ? sshHostConfig['PreferredAuthentications'].split(',') : ['publickey', 'password', 'keyboard-interactive'];
-                
+                const preferredAuthentications = sshHostConfig['PreferredAuthentications'] ? sshHostConfig['PreferredAuthentications'].split(',').map(s => s.trim()) : ['publickey', 'password', 'keyboard-interactive'];
+
                 const identityFiles: string[] = (sshHostConfig['IdentityFile'] as unknown as string[]) || [];
                 const identitiesOnly = (sshHostConfig['IdentitiesOnly'] || 'no').toLowerCase() === 'yes';
                 const identityKeys = await gatherIdentityFiles(identityFiles, this.sshAgentSock, identitiesOnly, this.logger);

--- a/src/ssh/sshConfig.ts
+++ b/src/ssh/sshConfig.ts
@@ -36,6 +36,7 @@ const SSH_CONFIG_PROPERTIES: Record<string, string> = {
     'identitiesonly': 'IdentitiesOnly',
     'identityfile': 'IdentityFile',
     'forwardagent': 'ForwardAgent',
+    'preferredauthentications': 'PreferredAuthentications',
     'proxyjump': 'ProxyJump',
     'proxycommand': 'ProxyCommand',
     'include': 'Include',


### PR DESCRIPTION
Allows the user to set either in the extension settings or in the ssh config file the option `PreferredAuthentications`, this in order to allow users to customize which authentication methods they want (or not) to use.