### PR TITLE
Support native resolution of the SSH config

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,6 +104,12 @@
 					"description": "**Experimental:** The name of the server binary, use this **only if** you are using a client without a corresponding server release",
 					"scope": "application",
 					"default": ""
+				},
+				"remote.SSH.experimental.nativeConfig": {
+					"type": "boolean",
+					"description": "**Experimental:** Query the host config by invoking `ssh -G hostname` instead of parsing the config files. Does not respect a custom config file.",
+					"scope": "application",
+					"default": false
 				}
 			}
 		},

--- a/src/hostTreeView.ts
+++ b/src/hostTreeView.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
-import SSHConfiguration, { getSSHConfigPath } from './ssh/sshConfig';
+import { ComputedSSHConfiguration, getSSHConfigPath } from './ssh/sshConfig';
 import { RemoteLocationHistory } from './remoteLocationHistory';
 import { Disposable } from './common/disposable';
 import { addNewHost, openRemoteSSHLocationWindow, openRemoteSSHWindow, openSSHConfigFile } from './commands';
@@ -74,7 +74,7 @@ export class HostTreeDataProvider extends Disposable implements vscode.TreeDataP
 
     async getChildren(element?: HostItem): Promise<DataTreeItem[]> {
         if (!element) {
-            const sshConfigFile = await SSHConfiguration.loadFromFS();
+            const sshConfigFile = await ComputedSSHConfiguration.loadFromFS();
             const hosts = sshConfigFile.getAllConfiguredHosts();
             return hosts.map(hostname => new HostItem(hostname, this.locationHistory.getHistory(hostname)));
         }


### PR DESCRIPTION
While trying to use this extension, it failed to connect to some machines that can be reached with a plain `ssh foo` on the command line. It turns out that the config parser used by this extension to decide if a proxy jump is required was dropping fields because it doesn't match the `HostName` against the patterns (which OpenSSH does). E.g.,

```
Host foo
  HostName foo.internal.com

Host *.internal.com
  ProxyJump proxy
```

It doesn't associate the `ProxyJump` with `foo`.

While bugs like this can be fixed, it is convenient to just defer to SSH itself when resolving the config. This makes it much more robust, especially against future changes by SSH.

This PR adds a 'native' resolver that is marked experimental and opt in. It just calls `ssh -G HOSTNAME` and loads in the output as the full config. It doesn't play well with custom SSH files paths, seemingly dropping the `ProxyJump` config when `-F /custom/config` is used (among other things, as well as ignoring the system config). Possibly other clients besides OpenSSH have different arguments to print the resolved config (or don't at all).