### PR TITLE
Use windows-x64 server on windows-arm64

### DIFF
--- a/src/serverSetup.ts
+++ b/src/serverSetup.ts
@@ -458,7 +458,8 @@ function printInstallResults($code) {
 
 # Check machine architecture
 $ARCH=$env:PROCESSOR_ARCHITECTURE
-if(($ARCH -eq "AMD64") -or ($ARCH -eq "IA64")) {
+# Use x64 version for ARM64, as it's not yet available.
+if(($ARCH -eq "AMD64") -or ($ARCH -eq "IA64") -or ($ARCH -eq "ARM64")) {
     $SERVER_ARCH="x64"
 }
 else {


### PR DESCRIPTION
Windows 11 on arm64 provides emulation for x64 binaries. Thus, it's possible to execute the x64 server to provide remote access.

Tested from a Linux machine connecting to a Volterra windows device.