### PR TITLE
Execute ProxyCommand in a shell

### DIFF
--- a/src/authResolver.ts
+++ b/src/authResolver.ts
@@ -161,6 +161,10 @@ export class RemoteSSHResolver implements vscode.RemoteAuthorityResolver, vscode
                         proxyCommand = `"${proxyCommand}"`;
                         proxyArgs = proxyArgs.map((arg) => arg.includes(' ') ? `"${arg}"` : arg);
                         options = { shell: true, windowsHide: true, windowsVerbatimArguments: true };
+                    } else {
+                        proxyCommand = `exec ${proxyCommand} ${proxyArgs.join(' ')}`;
+                        proxyArgs = [];
+                        options = { shell: true };
                     }
 
                     this.logger.trace(`Spawning ProxyCommand: ${proxyCommand} ${proxyArgs.join(' ')}`);


### PR DESCRIPTION
The ProxyCommand in my ssh config looks something like

    ProxyCommand foo --bar\=baz

The backslash ahead of = is definitely weird, but the ssh config gets generated by a Ruby script, and that's how Ruby's Shellwords.escape escapes tokens. This config works with ssh, but not open-remote-ssh because the backslash ends up in the argument passed to foo.

According to man ssh_config, "[ProxyCommand] is executed using the user's shell 'exec' directive to avoid a lingering shell process," so I guess ssh just substitutes the tokens in the string and executes the command in a shell, and the shell processes the backslash.

We can see that ssh doesn't try escaping tokens by running

    $ ssh -o ProxyCommand='printf "%%q\n" %h 1>&2' "foo bar"
    foo
    bar

Despite "foo bar" being one token, it gets passsed to printf as two arguments, so I guess if we want to match ssh's behaviour we should do the same? I'm not sure what's up with Windows, so I left it alone for now.