### PR TITLE
Add option to change server data directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,6 +104,12 @@
 					"description": "**Experimental:** The name of the server binary, use this **only if** you are using a client without a corresponding server release",
 					"scope": "application",
 					"default": ""
+				},
+				"remote.SSH.serverDataFolder": {
+					"type": "string",
+					"description": "The base path to install the server to instead of `~/.vscodium-server`.",
+					"scope": "application",
+					"default": ""
 				}
 			}
 		},

--- a/src/serverConfig.ts
+++ b/src/serverConfig.ts
@@ -26,6 +26,7 @@ export async function getVSCodeServerConfig(): Promise<IServerConfig> {
     const productJson = await getVSCodeProductJson();
 
     const customServerBinaryName = vscode.workspace.getConfiguration('remote.SSH.experimental').get<string>('serverBinaryName', '');
+    const customServerDataFolder = vscode.workspace.getConfiguration('remote.SSH').get<string>('serverDataFolder', '');
 
     return {
         version: vscode.version.replace('-insider',''),
@@ -33,7 +34,7 @@ export async function getVSCodeServerConfig(): Promise<IServerConfig> {
         quality: productJson.quality,
         release: productJson.release,
         serverApplicationName: customServerBinaryName || productJson.serverApplicationName,
-        serverDataFolderName: productJson.serverDataFolderName,
+        serverDataFolderName: customServerDataFolder || productJson.serverDataFolderName,
         serverDownloadUrlTemplate: productJson.serverDownloadUrlTemplate
     };
 }

--- a/src/serverSetup.ts
+++ b/src/serverSetup.ts
@@ -1,4 +1,5 @@
 import * as crypto from 'crypto';
+import { isAbsolute } from 'path';
 import Log from './common/logger';
 import { getVSCodeServerConfig } from './serverConfig';
 import SSHConnection from './ssh/sshConnection';
@@ -213,7 +214,7 @@ DISTRO_VSCODIUM_RELEASE="${release ?? ''}"
 SERVER_APP_NAME="${serverApplicationName}"
 SERVER_INITIAL_EXTENSIONS="${extensions}"
 SERVER_LISTEN_FLAG="${useSocketPath ? `--socket-path="$TMP_DIR/vscode-server-sock-${crypto.randomUUID()}"` : '--port=0'}"
-SERVER_DATA_DIR="$HOME/${serverDataFolderName}"
+SERVER_DATA_DIR="${(isAbsolute(serverDataFolderName) ? '' : '$HOME/') + serverDataFolderName}"
 SERVER_DIR="$SERVER_DATA_DIR/bin/$DISTRO_COMMIT"
 SERVER_SCRIPT="$SERVER_DIR/bin/$SERVER_APP_NAME"
 SERVER_LOGFILE="$SERVER_DATA_DIR/.$DISTRO_COMMIT.log"
@@ -386,7 +387,7 @@ if [[ -z $SERVER_RUNNING_PROCESS ]]; then
     SERVER_CONNECTION_TOKEN="${crypto.randomUUID()}"
     echo $SERVER_CONNECTION_TOKEN > $SERVER_TOKENFILE
 
-    $SERVER_SCRIPT --start-server --host=127.0.0.1 $SERVER_LISTEN_FLAG $SERVER_INITIAL_EXTENSIONS --connection-token-file $SERVER_TOKENFILE --telemetry-level off --enable-remote-auto-shutdown --accept-server-license-terms &> $SERVER_LOGFILE &
+    $SERVER_SCRIPT --start-server --host=127.0.0.1 $SERVER_LISTEN_FLAG $SERVER_INITIAL_EXTENSIONS --connection-token-file $SERVER_TOKENFILE --telemetry-level off --enable-remote-auto-shutdown --accept-server-license-terms --server-data-dir $SERVER_DATA_DIR &> $SERVER_LOGFILE &
     echo $! > $SERVER_PIDFILE
 else
     echo "Server script is already running $SERVER_SCRIPT"
@@ -446,7 +447,7 @@ $DISTRO_VSCODIUM_RELEASE="${release ?? ''}"
 $SERVER_APP_NAME="${serverApplicationName}"
 $SERVER_INITIAL_EXTENSIONS="${extensions}"
 $SERVER_LISTEN_FLAG="${useSocketPath ? `--socket-path="$TMP_DIR/vscode-server-sock-${crypto.randomUUID()}"` : '--port=0'}"
-$SERVER_DATA_DIR="$(Resolve-Path ~)\\${serverDataFolderName}"
+$SERVER_DATA_DIR="${(isAbsolute(serverDataFolderName) ? '' : '$(Resolve-Path ~)\\') + serverDataFolderName}"
 $SERVER_DIR="$SERVER_DATA_DIR\\bin\\$DISTRO_COMMIT"
 $SERVER_SCRIPT="$SERVER_DIR\\bin\\$SERVER_APP_NAME.cmd"
 $SERVER_LOGFILE="$SERVER_DATA_DIR\\.$DISTRO_COMMIT.log"
@@ -552,7 +553,7 @@ else {
     $SERVER_CONNECTION_TOKEN="${crypto.randomUUID()}"
     [System.IO.File]::WriteAllLines($SERVER_TOKENFILE, $SERVER_CONNECTION_TOKEN)
 
-    $SCRIPT_ARGUMENTS="--start-server --host=127.0.0.1 $SERVER_LISTEN_FLAG $SERVER_INITIAL_EXTENSIONS --connection-token-file $SERVER_TOKENFILE --telemetry-level off --enable-remote-auto-shutdown --accept-server-license-terms *> '$SERVER_LOGFILE'"
+    $SCRIPT_ARGUMENTS="--start-server --host=127.0.0.1 $SERVER_LISTEN_FLAG $SERVER_INITIAL_EXTENSIONS --connection-token-file $SERVER_TOKENFILE --telemetry-level off --enable-remote-auto-shutdown --accept-server-license-terms --server-data-dir $SERVER_DATA_DIR *> '$SERVER_LOGFILE'"
 
     $START_ARGUMENTS = @{
         FilePath = "powershell.exe"


### PR DESCRIPTION
This adds the `remote.SSH.serverDataFolder` option to choose an alternative server data directory. Instead of being hardcoded to something like `~/.vscodium-server`, it can be placed somewhere else such as in `~/.config`. `$HOME` is prepended to any relative paths.