### PR TITLE
feat: add riscv64 support

### DIFF
--- a/src/serverSetup.ts
+++ b/src/serverSetup.ts
@@ -280,6 +280,9 @@ case $ARCH in
     ppc64le)
         SERVER_ARCH="ppc64le"
         ;;
+    riscv64)
+        SERVER_ARCH="riscv64"
+        ;;
     *)
         echo "Error architecture not supported: $ARCH"
         print_install_results_and_exit 1


### PR DESCRIPTION
This PR adds riscv64 support.

~~And it moves the platform/architecture checking logic after checking if the server exists because people might try to use this extension before their architecture is supported. (Will be a future PR)~~