### PR TITLE
authResolver: allow manually setting server connection info

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,6 +104,30 @@
 					"description": "**Experimental:** The name of the server binary, use this **only if** you are using a client without a corresponding server release",
 					"scope": "application",
 					"default": ""
+				},
+				"remote.SSH.experimental.connections": {
+					"type": "object",
+					"description": "**Experimental:** Server connection info for hosts",
+					"scope": "application",
+					"additionalProperties": {
+						"type": "object",
+						"properties": {
+							"listeningOn": {
+								"type": [
+									"number",
+									"string"
+								],
+								"description": "The TCP port number, or Unix domain socket path where the server listening on"
+							},
+							"connectionToken": {
+								"type": "string",
+								"description": "Sever connection token."
+							}
+						},
+						"required": [
+							"listeningOn"
+						]
+					}
 				}
 			}
 		},

--- a/src/serverSetup.ts
+++ b/src/serverSetup.ts
@@ -17,10 +17,16 @@ export interface ServerInstallOptions {
     serverDownloadUrlTemplate: string;
 }
 
-export interface ServerInstallResult {
-    exitCode: number;
+/**
+ * Information required for running server connection.
+ */
+export interface ConnectionInfo {
     listeningOn: number | string;
-    connectionToken: string;
+    connectionToken?: string;
+}
+
+export interface ServerInstallResult extends ConnectionInfo {
+    exitCode: number;
     logFile: string;
     osReleaseId: string;
     arch: string;


### PR DESCRIPTION
Add a new configuration `experimental.connections` to allow managing remote server manually.

Our installtion scripts are proved to be working at almost all major platforms. However, it is generally hard to maintain all combinations in simple shell scripts.

For example:

    1. pre-compiled NodeJS may require glibc, what about musl?
    2. New architecture?
    3. Non linux/windows NT/darwin kernel?

This PR addresses this problem by offloading "server installtion" process to end-users who want to customize server lifetime.