### PR TITLE
Prevent log file not found error before any outputs

### DIFF
--- a/src/serverSetup.ts
+++ b/src/serverSetup.ts
@@ -366,6 +366,7 @@ if [[ -z $SERVER_RUNNING_PROCESS ]]; then
         rm $SERVER_TOKENFILE
     fi
 
+    touch $SERVER_LOGFILE
     touch $SERVER_TOKENFILE
     chmod 600 $SERVER_TOKENFILE
     SERVER_CONNECTION_TOKEN="${crypto.randomUUID()}"


### PR DESCRIPTION
Kept getting this error no matter what, even running the script locally.
`Error server log file not found /root/.vscodium-server/.21b1e2955ddda36eeba3a94e643128e465285b93.log`

Added one line to fix.