### PR TITLE
add s390x support

### DIFF
--- a/src/serverSetup.ts
+++ b/src/serverSetup.ts
@@ -283,6 +283,9 @@ case $ARCH in
     riscv64)
         SERVER_ARCH="riscv64"
         ;;
+    s390x)
+        SERVER_ARCH="s390x"
+        ;;
     *)
         echo "Error architecture not supported: $ARCH"
         print_install_results_and_exit 1


### PR DESCRIPTION
This PR extends the open-remote-ssh extension of VSCodium with support for the s390x architecture (IBM Mainframe / System Z)

Prerequisite PR on VSCodium: https://github.com/VSCodium/vscodium/pull/2099