### PR TITLE
Add support for loong64

### DIFF
--- a/src/serverSetup.ts
+++ b/src/serverSetup.ts
@@ -283,6 +283,9 @@ case $ARCH in
     riscv64)
         SERVER_ARCH="riscv64"
         ;;
+    loongarch64)
+        SERVER_ARCH="loong64"
+        ;;
     *)
         echo "Error architecture not supported: $ARCH"
         print_install_results_and_exit 1


### PR DESCRIPTION
This PR adds support for loong64, a RISC-style ISA developed by Loongson.

Loong64 support for REH server of VSCodium is already merged and released: https://github.com/VSCodium/vscodium/releases/tag/1.95.2.24313