### PR TITLE
fix: add missing direct @types/ssh2-stream dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -349,6 +349,7 @@
 	"devDependencies": {
 		"@types/node": "^16.11.0",
 		"@types/ssh2": "^0.5.52",
+		"@types/ssh2-streams": "0.1.12",
 		"@types/webpack": "^5.28.0",
 		"@typescript-eslint/eslint-plugin": "^5.19.0",
 		"@typescript-eslint/parser": "^5.19.0",

--- a/src/authResolver.ts
+++ b/src/authResolver.ts
@@ -5,7 +5,7 @@ import * as stream from 'stream';
 import { SocksClient, SocksClientOptions } from 'socks';
 import * as vscode from 'vscode';
 import * as ssh2 from 'ssh2';
-import { ParsedKey } from 'ssh2-streams';
+import type { ParsedKey } from 'ssh2-streams';
 import Log from './common/logger';
 import SSHDestination from './ssh/sshDestination';
 import SSHConnection, { SSHTunnelConfig } from './ssh/sshConnection';

--- a/src/authResolver.ts
+++ b/src/authResolver.ts
@@ -121,7 +121,7 @@ export class RemoteSSHResolver implements vscode.RemoteAuthorityResolver, vscode
                         });
                     for (let i = 0; i < proxyJumps.length; i++) {
                         const [proxy, proxyHostConfig] = proxyJumps[i];
-                        const proxyhHostName = proxyHostConfig['HostName'] || proxy.hostname;
+                        const proxyHostName = proxyHostConfig['HostName'] || proxy.hostname;
                         const proxyUser = proxyHostConfig['User'] || proxy.user || sshUser;
                         const proxyPort = proxyHostConfig['Port'] ? parseInt(proxyHostConfig['Port'], 10) : (proxy.port || sshPort);
 
@@ -132,9 +132,9 @@ export class RemoteSSHResolver implements vscode.RemoteAuthorityResolver, vscode
                         const proxyIdentitiesOnly = (proxyHostConfig['IdentitiesOnly'] || 'no').toLowerCase() === 'yes';
                         const proxyIdentityKeys = await gatherIdentityFiles(proxyIdentityFiles, this.sshAgentSock, proxyIdentitiesOnly, this.logger);
 
-                        const proxyAuthHandler = this.getSSHAuthHandler(proxyUser, proxyhHostName, proxyIdentityKeys, preferredAuthentications);
+                        const proxyAuthHandler = this.getSSHAuthHandler(proxyUser, proxyHostName, proxyIdentityKeys, preferredAuthentications);
                         const proxyConnection = new SSHConnection({
-                            host: !proxyStream ? proxyhHostName : undefined,
+                            host: !proxyStream ? proxyHostName : undefined,
                             port: !proxyStream ? proxyPort : undefined,
                             sock: proxyStream,
                             username: proxyUser,

--- a/src/serverSetup.ts
+++ b/src/serverSetup.ts
@@ -40,7 +40,7 @@ const DEFAULT_DOWNLOAD_URL_TEMPLATE = 'https://github.com/VSCodium/vscodium/rele
 export async function installCodeServer(conn: SSHConnection, serverDownloadUrlTemplate: string | undefined, extensionIds: string[], envVariables: string[], platform: string | undefined, useSocketPath: boolean, logger: Log): Promise<ServerInstallResult> {
     let shell = 'powershell';
 
-    // detect plaform and shell for windows
+    // detect platform and shell for windows
     if (!platform || platform === 'windows') {
         const result = await conn.exec('uname -s');
 
@@ -409,7 +409,7 @@ if [[ -f $SERVER_LOGFILE ]]; then
     done
 
     if [[ -z $LISTENING_ON ]]; then
-        echo "Error server did not start sucessfully"
+        echo "Error server did not start successfully"
         print_install_results_and_exit 1
     fi
 else

--- a/src/ssh/identityFiles.ts
+++ b/src/ssh/identityFiles.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import * as crypto from 'crypto';
-import { ParsedKey } from 'ssh2-streams';
+import type { ParsedKey } from 'ssh2-streams';
 import * as ssh2 from 'ssh2';
 import { untildify, exists as fileExists } from '../common/files';
 import Log from '../common/logger';

--- a/yarn.lock
+++ b/yarn.lock
@@ -158,6 +158,13 @@
   dependencies:
     "@types/node" "*"
 
+"@types/ssh2-streams@0.1.12":
+  version "0.1.12"
+  resolved "https://registry.yarnpkg.com/@types/ssh2-streams/-/ssh2-streams-0.1.12.tgz#e68795ba2bf01c76b93f9c9809e1f42f0eaaec5f"
+  integrity sha512-Sy8tpEmCce4Tq0oSOYdfqaBpA3hDM8SoxoFh5vzFsu2oL+znzGz8oVWW7xb4K920yYMUY+PIG31qZnFMfPWNCg==
+  dependencies:
+    "@types/node" "*"
+
 "@types/ssh2@^0.5.52":
   version "0.5.52"
   resolved "https://registry.yarnpkg.com/@types/ssh2/-/ssh2-0.5.52.tgz#9dbd8084e2a976e551d5e5e70b978ed8b5965741"


### PR DESCRIPTION
ssh2-stream is being used directly while not listed in the dependencies. Yarn hoists the packages, but a package manager like pnpm doesn't, so it's better to declare it explicitly if imported.
Also fixed some typos.