### PR TITLE
fix: Win32 internal error "Access is denied" 0x5

### DIFF
--- a/src/serverSetup.ts
+++ b/src/serverSetup.ts
@@ -418,6 +418,7 @@ function generatePowerShellInstallScript({ id, quality, version, commit, release
 # Server installation script
 
 $TMP_DIR="$env:TEMP\\$([System.IO.Path]::GetRandomFileName())"
+$ProgressPreference = "SilentlyContinue"
 
 $DISTRO_VERSION="${version}"
 $DISTRO_COMMIT="${commit}"


### PR DESCRIPTION
Got the same issue as https://github.com/crc-org/crc/issues/1184 in this extension

Adding a file `C:\Users\USER\Documents\WindowsPowerShell\Microsoft.PowerShell_profile.ps1`

With the following content 
`$ProgressPreference = "SilentlyContinue"`

Is a workaround because it will have the variable set on the powershell profile