### PR TITLE
Update serverSetup.ts | Add shebang to Bash install script for compatibility

### DIFF
--- a/src/serverSetup.ts
+++ b/src/serverSetup.ts
@@ -201,6 +201,7 @@ function parseServerInstallOutput(str: string, scriptId: string): { [k: string]:
 function generateBashInstallScript({ id, quality, version, commit, release, extensionIds, envVariables, useSocketPath, serverApplicationName, serverDataFolderName, serverDownloadUrlTemplate }: ServerInstallOptions) {
     const extensions = extensionIds.map(id => '--install-extension ' + id).join(' ');
     return `
+#!/bin/sh
 # Server installation script
 
 TMP_DIR="\${XDG_RUNTIME_DIR:-"/tmp"}"

--- a/src/serverSetup.ts
+++ b/src/serverSetup.ts
@@ -201,7 +201,7 @@ function parseServerInstallOutput(str: string, scriptId: string): { [k: string]:
 function generateBashInstallScript({ id, quality, version, commit, release, extensionIds, envVariables, useSocketPath, serverApplicationName, serverDataFolderName, serverDownloadUrlTemplate }: ServerInstallOptions) {
     const extensions = extensionIds.map(id => '--install-extension ' + id).join(' ');
     return `
-#!/bin/sh
+#!/usr/bin/env sh
 # Server installation script
 
 TMP_DIR="\${XDG_RUNTIME_DIR:-"/tmp"}"


### PR DESCRIPTION
This should extend support for linux servers whose default shell is not compatible with the embedded shell script