### PR TITLE
fix: default won't overwrite editor's value

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,8 +77,7 @@
 				"remote.SSH.serverDownloadUrlTemplate": {
 					"type": "string",
 					"description": "The URL from where the vscode server will be downloaded. You can use the following variables and they will be replaced dynamically:\n- ${quality}: vscode server quality, e.g. stable or insiders\n- ${version}: vscode server version, e.g. 1.69.0\n- ${commit}: vscode server release commit\n- ${arch}: vscode server arch, e.g. x64, armhf, arm64\n- ${release}: release number, vscodium only https://github.com/VSCodium/vscodium/pull/1192",
-					"scope": "application",
-					"default": "https://github.com/VSCodium/vscodium/releases/download/${version}.${release}/vscodium-reh-${os}-${arch}-${version}.${release}.tar.gz"
+					"scope": "application"
 				},
 				"remote.SSH.remotePlatform": {
 					"type": "object",

--- a/src/serverSetup.ts
+++ b/src/serverSetup.ts
@@ -81,7 +81,7 @@ export async function installCodeServer(conn: SSHConnection, serverDownloadUrlTe
         useSocketPath,
         serverApplicationName: vscodeServerConfig.serverApplicationName,
         serverDataFolderName: vscodeServerConfig.serverDataFolderName,
-        serverDownloadUrlTemplate: serverDownloadUrlTemplate ?? vscodeServerConfig.serverDownloadUrlTemplate ?? DEFAULT_DOWNLOAD_URL_TEMPLATE,
+        serverDownloadUrlTemplate: serverDownloadUrlTemplate || vscodeServerConfig.serverDownloadUrlTemplate || DEFAULT_DOWNLOAD_URL_TEMPLATE,
     };
 
     let commandOutput: { stdout: string; stderr: string };


### PR DESCRIPTION
Hi,

The way how default value have changed in Visual Studio Code.

Previously, if the property wasn't defined in the config, `remoteSSHconfig.get<string>('serverDownloadUrlTemplate')` was returning `undefined`.
Now, it will return the default value from the `package.json` or an empty string.

This PR is quite urgent since I'm removing the release number from VSCodium (https://github.com/VSCodium/vscodium/pull/2299).

@jeanp413 Can you merge it before the next release by next week? Thx

If you need help to maintain the project, I will be happy to help.