### PR TITLE
fix: replace 'which' usage for 'command -v'

### DIFF
--- a/src/serverSetup.ts
+++ b/src/serverSetup.ts
@@ -333,9 +333,9 @@ if [[ ! -f $SERVER_SCRIPT ]]; then
 
     pushd $SERVER_DIR > /dev/null
 
-    if [[ ! -z $(which wget) ]]; then
+    if [[ ! -z $(command -v wget) ]]; then
         wget --tries=3 --timeout=10 --continue --no-verbose -O vscode-server.tar.gz $SERVER_DOWNLOAD_URL
-    elif [[ ! -z $(which curl) ]]; then
+    elif [[ ! -z $(command -v curl) ]]; then
         curl --retry 3 --connect-timeout 10 --location --show-error --silent --output vscode-server.tar.gz $SERVER_DOWNLOAD_URL
     else
         echo "Error no tool to download server binary"


### PR DESCRIPTION
'which' is not standard and just happens to be installed almost everywhere, but not on my machine. 'command -v' however _is_ standard POSIX, accomplishes the same thing, and is _actually_ available everywhere.