### PR TITLE
Use `dir ..` for shell detection on Windows instead of `uname -s`

### DIFF
--- a/src/serverSetup.ts
+++ b/src/serverSetup.ts
@@ -42,23 +42,16 @@ export async function installCodeServer(conn: SSHConnection, serverDownloadUrlTe
 
     // detect platform and shell for windows
     if (!platform || platform === 'windows') {
-        const result = await conn.exec('uname -s');
+        const result = await conn.exec('dir ..');
 
         if (result.stdout) {
-            if (result.stdout.includes('windows32')) {
-                platform = 'windows';
-            } else if (result.stdout.includes('MINGW64')) {
-                platform = 'windows';
-                shell = 'bash';
-            }
-        } else if (result.stderr) {
-            if (result.stderr.includes('FullyQualifiedErrorId : CommandNotFoundException')) {
-                platform = 'windows';
-            }
-
-            if (result.stderr.includes('is not recognized as an internal or external command')) {
-                platform = 'windows';
+            platform = 'windows';
+            if (result.stdout.includes('LastWriteTime')) {
+                shell = 'powershell';
+            } else if (result.stdout.includes('<DIR>')) {
                 shell = 'cmd';
+            } else {
+                shell = 'bash';
             }
         }
 


### PR DESCRIPTION
Addresses the issue raised in #164 by updating how shell detection is performed on Windows.

`dir` has demonstrable differences between its invocations in `powershell`, `cmd`, and (git) `bash`, except on an empty directory. `..` is likely non-empty, except in weird permissions/home directory scenarios.

Another edge case which remains untested is that of different locales. I tried setting both system and user locales to `es-MX` but could not get a response in `powershell`/`cmd` that was not in English.

Below are samples of `dir ..` on `powershell`, `cmd`, and `bash`.

`powershell`:

```powershell
    Directory: C:\Users


Mode                 LastWriteTime         Length Name
----                 -------------         ------ ----
d-----        11/19/2025   5:12 PM                0
d-r---         1/18/2025   5:11 PM                Public
```

`cmd`:

```cmd
 Volume in drive C has no label.
 Volume Serial Number is ECAB-EE57

 Directory of C:\Users

02/16/2025  08:05 PM    <DIR>          .
11/19/2025  05:12 PM    <DIR>          0
01/18/2025  05:11 PM    <DIR>          Public
               0 File(s)              0 bytes
               3 Dir(s)  908,322,545,664 bytes free
```

`bash`:

```bash
0  All\ Users  Default  Default\ User  desktop.ini  Public
```