### PR TITLE
Allow automatic download of remote extension host on FreeBSD

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ You can connect to a running SSH server on the following platforms.
 - ARMv8l (AArch64) Ubuntu 18.04+ (64-bit).
 - macOS 10.14+ (Mojave)
 - Windows 10+
-- FreeBSD 13 (Requires manual remote-extension-host installation)
+- FreeBSD 13+ (Requires custom serverDownloadUrlTemplate setting)
 - DragonFlyBSD (Requires manual remote-extension-host installation)
 
 ## Requirements

--- a/src/serverSetup.ts
+++ b/src/serverSetup.ts
@@ -323,7 +323,7 @@ SERVER_DOWNLOAD_URL="$(echo "${serverDownloadUrlTemplate.replace(/\$\{/g, '\\${'
 # Check if server script is already installed
 if [[ ! -f $SERVER_SCRIPT ]]; then
     case "$PLATFORM" in
-        darwin | linux | alpine )
+        darwin | linux | alpine | freebsd )
             ;;
         *)
             echo "Error '$PLATFORM' needs manual installation of remote extension host"
@@ -337,6 +337,8 @@ if [[ ! -f $SERVER_SCRIPT ]]; then
         wget --tries=3 --timeout=10 --continue --no-verbose -O vscode-server.tar.gz $SERVER_DOWNLOAD_URL
     elif [[ ! -z $(which curl) ]]; then
         curl --retry 3 --connect-timeout 10 --location --show-error --silent --output vscode-server.tar.gz $SERVER_DOWNLOAD_URL
+    elif [[ ! -z $(which fetch) ]]; then
+        fetch --retry --timeout=10 --quiet --output=vscode-server.tar.gz $SERVER_DOWNLOAD_URL
     else
         echo "Error no tool to download server binary"
         print_install_results_and_exit 1

--- a/src/serverSetup.ts
+++ b/src/serverSetup.ts
@@ -337,7 +337,7 @@ if [[ ! -f $SERVER_SCRIPT ]]; then
         wget --tries=3 --timeout=10 --continue --no-verbose -O vscode-server.tar.gz $SERVER_DOWNLOAD_URL
     elif command -v curl >/dev/null 2>&1; then
         curl --retry 3 --connect-timeout 10 --location --show-error --silent --output vscode-server.tar.gz $SERVER_DOWNLOAD_URL
-    elif [[ ! -z $(which fetch) ]]; then
+    elif command -v fetch >/dev/null 2>&1; then
         fetch --retry --timeout=10 --quiet --output=vscode-server.tar.gz $SERVER_DOWNLOAD_URL
     else
         echo "Error no tool to download server binary"


### PR DESCRIPTION
I started hosting remote extension host for FreeBSD (and also Linux) at the following URL:
https://github.com/tagattie/FreeBSD-VSCode/releases

By setting `remote.SSH.serverDownloadUrlTemplate` to the following value:
`https://github.com/tagattie/FreeBSD-VSCode/releases/download/${version}/vscode-reh-${os}-${arch}-${version}.tar.gz`

no manual installation of remote extension host should be necessary when users of VSCode on FreeBSD connect to remote FreeBSD/Linux hosts.

In addition, make it try to use `fetch` when either `wget` or `curl` is not available. (`fetch` is available on FreeBSD by default).