### PR TITLE
fix: parsing errors when the remote hostname contains uppercase letters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.0.49
+- Fixed parsing errors when the remote hostname contains uppercase letters
+
 ## 0.0.48
 - Support `%n` in ProxyCommand
 - fix: add missing direct @types/ssh2-stream dependency (#177)

--- a/src/ssh/sshDestination.ts
+++ b/src/ssh/sshDestination.ts
@@ -49,6 +49,8 @@ export default class SSHDestination {
     }
 
     toEncodedString(): string {
-        return this.toString().replace(/[A-Z]/g, (ch) => `\\x${ch.charCodeAt(0).toString(16).toLowerCase()}`);
+        const data = { hostName: this.hostname, user: this.user, port: this.port };
+        const json = JSON.stringify(data);
+        return Buffer.from(json).toString('hex');
     }
 }


### PR DESCRIPTION
Fixes https://github.com/jeanp413/open-remote-ssh/issues/251