### PR TITLE
fix: don't assume ProxyCommand value's type

### DIFF
--- a/src/authResolver.ts
+++ b/src/authResolver.ts
@@ -154,7 +154,8 @@ export class RemoteSSHResolver implements vscode.RemoteAuthorityResolver, vscode
                         proxyStream = await proxyConnection.forwardOut('127.0.0.1', 0, destIP, destPort);
                     }
                 } else if (sshHostConfig['ProxyCommand']) {
-                    let proxyArgs = (sshHostConfig['ProxyCommand'] as unknown as string[])
+                    let proxyArgs = ([] as string[])
+						.concat(sshHostConfig['ProxyCommand'])
                         .map((arg) => arg.replace('%h', sshHostName).replace('%n', sshDest.hostname).replace('%p', sshPort.toString()).replace('%r', sshUser));
                     let proxyCommand = proxyArgs.shift()!;
 

--- a/src/ssh/sshConfig.ts
+++ b/src/ssh/sshConfig.ts
@@ -18,7 +18,7 @@ export type HostConfiguration = {
 	ProxyCommand?: string | string[];
 	SendEnv?: string | string[];
 	UserKnownHostsFile?: string | string[];
-} & Record<string, string>
+} & Record<string, string>;
 
 const systemSSHConfig = isWindows ? path.resolve(process.env.ALLUSERSPROFILE || 'C:\\ProgramData', 'ssh\\ssh_config') : '/etc/ssh/ssh_config';
 const defaultSSHConfigPath = path.resolve(os.homedir(), '.ssh/config');

--- a/src/ssh/sshConfig.ts
+++ b/src/ssh/sshConfig.ts
@@ -7,6 +7,19 @@ import { exists as fileExists, normalizeToSlash, untildify } from '../common/fil
 import { isWindows } from '../common/platform';
 import { glob } from 'glob';
 
+// Only a few directives might return an array
+// https://github.com/cyjake/ssh-config/blob/master/src/ssh-config.ts#L10
+export type HostConfiguration = {
+	CanonicalDomains?: string | string[];
+	GlobalKnownHostsFile?: string | string[];
+	Host?: string | string[];
+	IPQoS?: string | string[];
+	Match?: string | string[];
+	ProxyCommand?: string | string[];
+	SendEnv?: string | string[];
+	UserKnownHostsFile?: string | string[];
+} & Record<string, string>
+
 const systemSSHConfig = isWindows ? path.resolve(process.env.ALLUSERSPROFILE || 'C:\\ProgramData', 'ssh\\ssh_config') : '/etc/ssh/ssh_config';
 const defaultSSHConfigPath = path.resolve(os.homedir(), '.ssh/config');
 
@@ -117,9 +130,7 @@ export default class SSHConfiguration {
         return [...hosts.keys()];
     }
 
-    getHostConfiguration(host: string): Record<string, string> {
-        // Only a few directives return an array
-        // https://github.com/jeanp413/ssh-config/blob/8d187bb8f1d83a51ff2b1d127e6b6269d24092b5/src/ssh-config.ts#L9C1-L9C118
-        return this.sshConfig.compute(host) as Record<string, string>;
+    getHostConfiguration(host: string): HostConfiguration {
+        return this.sshConfig.compute(host) as HostConfiguration;
     }
 }


### PR DESCRIPTION
This PR fixes the assumption that `ProxyCommand` is always a `string[]`.
It also adds a type to avoid such assumption.

References:
- #269
