### PR TITLE
fix: split ProxyCommand into argv tokens before spawn

### DIFF
--- a/src/authResolver.ts
+++ b/src/authResolver.ts
@@ -49,6 +49,60 @@ interface SSHKey {
     isPrivate?: boolean;
 }
 
+
+/**
+ * Split a ProxyCommand value into argv tokens.
+ *
+ * ssh-config v5.0.0 reassembles ProxyCommand's value into a single string (to
+ * preserve quoting across the param boundary), but the spawn code expects
+ * individual argv tokens. Calling `[].concat(someString)` does NOT split the
+ * string — it wraps it, so `spawn()` ends up receiving the whole command
+ * line as the executable path and fails with ENOENT. See
+ * https://github.com/jeanp413/open-remote-ssh/issues/271 and
+ * https://github.com/jeanp413/open-remote-ssh/issues/273.
+ *
+ * This helper mirrors OpenSSH's own ProxyCommand tokenization:
+ * - whitespace separates tokens (outside quotes)
+ * - double quotes group a single token
+ * - backslash escapes the next character
+ *
+ * Array inputs are passed through for defensive compatibility with older
+ * ssh-config versions.
+ */
+function splitProxyCommand(value: string | string[]): string[] {
+    if (Array.isArray(value)) {return value.slice();}
+    const out: string[] = [];
+    let cur = '';
+    let i = 0;
+    let quoted = false;
+    let hasToken = false;
+    while (i < value.length) {
+        const ch = value[i];
+        if (ch === '\\' && i + 1 < value.length) {
+            cur += value[i + 1];
+            i += 2;
+            hasToken = true;
+            continue;
+        }
+        if (ch === '"') {
+            quoted = !quoted;
+            hasToken = true;
+            i += 1;
+            continue;
+        }
+        if (!quoted && /\s/.test(ch)) {
+            if (hasToken) { out.push(cur); cur = ''; hasToken = false; }
+            i += 1;
+            continue;
+        }
+        cur += ch;
+        hasToken = true;
+        i += 1;
+    }
+    if (hasToken) {out.push(cur);}
+    return out;
+}
+
 export class RemoteSSHResolver implements vscode.RemoteAuthorityResolver, vscode.Disposable {
 
     private proxyConnections: SSHConnection[] = [];
@@ -154,8 +208,7 @@ export class RemoteSSHResolver implements vscode.RemoteAuthorityResolver, vscode
                         proxyStream = await proxyConnection.forwardOut('127.0.0.1', 0, destIP, destPort);
                     }
                 } else if (sshHostConfig['ProxyCommand']) {
-                    let proxyArgs = ([] as string[])
-						.concat(sshHostConfig['ProxyCommand'])
+                    let proxyArgs = splitProxyCommand(sshHostConfig['ProxyCommand'] as unknown as string | string[])
                         .map((arg) => arg.replace('%h', sshHostName).replace('%n', sshDest.hostname).replace('%p', sshPort.toString()).replace('%r', sshUser));
                     let proxyCommand = proxyArgs.shift()!;
 


### PR DESCRIPTION
## Summary

Fixes #271 and #273. Any user with a `ProxyCommand` in `~/.ssh/config` on
v0.1.1 currently gets `Error: Connection lost before handshake` on Linux/macOS
or `write EPIPE` on Windows, even though the same `ProxyCommand` works fine
with the system `ssh` client and with Microsoft's Remote-SSH extension.

## Root cause

`ssh-config` v5.0.0 deliberately [changed `compute()` to return
`ProxyCommand` as a single reassembled string](https://github.com/cyjake/ssh-config/blob/v5.1.0/src/ssh-config.ts),
in order to preserve quoting across token boundaries:

```ts
// ssh-config's compute()
if (/ProxyCommand/i.test(key)) {
    val = value.map(({ val, separator, quoted }) =>
        `${separator}${quoted ? `"${val.replace(/"/g, '\\"')}"` : val}`
    ).join('').trim();
}
```

The spawn code in `authResolver.ts` was updated to `[].concat(...)` to
tolerate a string value, but `Array.prototype.concat(someString)` **wraps**
the string in a one-element array — it does **not** split it:

```ts
[].concat('/usr/local/bin/wssh proxy %h')
// => ['/usr/local/bin/wssh proxy %h']   ← one element
```

So after the map+shift, the spawn call becomes:

```ts
cp.spawn('/usr/local/bin/wssh proxy devhost.example.com', [], {})
```

On Linux/macOS (where `shell` is not set), `spawn` tries to exec a file
literally named `/usr/local/bin/wssh proxy devhost.example.com`, which
doesn't exist — `ENOENT`. On Windows with a non-`.bat`/`.cmd` proxy command
the equivalent happens through the cmd shell path and surfaces as `EPIPE`.

The child dies before any byte reaches the `Duplex.from({readable, writable})`
wrapper. `ssh2.Client` takes its `e.sock` branch, synthesizes a `connect`
event (because `sock.connecting` is not a boolean), starts its ready timeout,
and then the now-closed wrapper stream emits `'close'`. That triggers the
internal `ue()` handler which sees `connected && !handshaked` and reports
the generic `Connection lost before handshake` — hiding the actual ENOENT
error entirely.

## Fix

Replace `([] as string[]).concat(sshHostConfig['ProxyCommand'])` with a real
argv tokenizer that:

- splits on whitespace outside of quotes,
- respects double-quoted segments,
- honors backslash escapes,
- passes arrays through unchanged, for defensive compatibility with older
  `ssh-config` versions.

This mirrors how OpenSSH itself parses `ProxyCommand` values. The
Windows `.bat`/`.cmd` branch below the spawn is unchanged; after the
splitter it sees the expected individual tokens and continues to apply
its shell-quoting logic.

## Verification

- `npm run compile:src` → clean
- `npm run lint` → clean (no new warnings)
- `npm run bundle` → produces `lib/extension.js`, webpack prints
  `compiled successfully`
- Replaced the installed `jeanp413.open-remote-ssh-0.1.1-universal/lib/extension.js`
  with the bundle built from this branch, on a machine that was hitting #271,
  and the extension now successfully connects through an Amazon `wssh proxy %h`
  ProxyCommand.
- A minimal reproducer that spawns via `spawn(whole_command, [])` and wraps
  the stdio in `Duplex.from` reproduces the exact user-visible error before
  the fix and succeeds after.

## Notes

- No change in public behavior for users whose `ProxyCommand` is already
  simple (e.g. `ssh -W %h:%p bastion`).
- Quoted paths with spaces now work correctly (e.g. `"/C/Program Files/OpenSSH/ssh.exe" -W %h:%p bastion`),
  where previously on Linux/macOS they also failed silently in the same way.
- #272 ("no hosts shown") is a different bug and is not touched by this PR.
