### PR TITLE
docs: improve README for the vscode-oss compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,15 +57,16 @@ If you are using VSCode-OSS instead of VSCodium, you need some extra steps to ma
 Modify the following entries in the plugin settings:
 
 ```
-"remote.SSH.experimental.serverBinaryName": "codium-server",
+"remote.SSH.serverBinaryName": "codium-server",
 "remote.SSH.serverDownloadUrlTemplate": "https://github.com/VSCodium/vscodium/releases/download/${version}${release}/vscodium-reh-${os}-${arch}-${version}${release}.tar.gz",
 "remote.SSH.serverVersion": "latest",
 "remote.SSH.serverValidation": "force",
 ```
 
 VSCodium versions have an extra `release` part that do not have equivalent for VSCode-OSS.
-The plugin will install the latest release of VSCodium if `serverVersion` is set to "latest".
-If you need to match the VSCode-OSS version, set `serverVersion` to "closest", to
+So leaving `serverVersion` to the default `"match"` will fail.
+The plugin will install the latest release of VSCodium if `serverVersion` is set to `"latest"`.
+If you need to match the VSCode-OSS version, set `serverVersion` to `"closest"`, to
 automatically fetch the last release of VSCodium for this version.
 
 You can look for the release numbers associated with your VSCode version in the
@@ -76,8 +77,10 @@ You can also set `serverVersion` to a specic version (e.g. "1.116.0") or a speci
 version-release (e.g. "1.116.02821").
 
 If the local and remote VSCodium versions don't match, which will be the case on VSCode-OSS,
-remote server validation needs to be bypassed. Setting `serverValidation` to "force" will
-modify the commit of the remote server to make it matche your local VSCode commit.
+remote server validation needs to be bypassed. Setting `serverValidation` to `"force"` will
+modify the commit of the remote server to make it match the local VSCode commit.
+If `serverValidation` is set to `"skip"`, the remote server will skip checking that the commits
+match. This option is working only if the remote VSCodium version is `>=1.120`.
 
 Starting with VSCodium version 1.99.0, the `release` number is not separated from the `version` by a dot `.` anymore.
 Therefore `serverDownloadUrlTemplate` needs to be filled with the new scheme (as shown above).

--- a/src/serverConfig.ts
+++ b/src/serverConfig.ts
@@ -30,7 +30,7 @@ export type IServerConfig = {
 export async function getVSCodeServerConfig(): Promise<IServerConfig> {
     const productJson = await getVSCodeProductJson();
 
-    const customServerBinaryName = vscode.workspace.getConfiguration('remote.SSH.experimental').get<string>('serverBinaryName', '');
+    const customServerBinaryName = vscode.workspace.getConfiguration('remote.SSH').get<string>('serverBinaryName', '');
     const serverValidation = vscode.workspace.getConfiguration('remote.SSH').get<ServerValidation>('serverValidation', 'strict');
 
     return {


### PR DESCRIPTION
follow-up from #189 