### PR TITLE
fix: change fallback value for serverDownloadUrlTemplate

### DIFF
--- a/src/serverSetup.ts
+++ b/src/serverSetup.ts
@@ -92,7 +92,7 @@ export class ServerInstallError extends Error {
     }
 }
 
-const DEFAULT_DOWNLOAD_URL_TEMPLATE = 'https://github.com/VSCodium/vscodium/releases/download/${version}.${release}/vscodium-reh-${os}-${arch}-${version}.${release}.tar.gz';
+const DEFAULT_DOWNLOAD_URL_TEMPLATE = 'https://github.com/VSCodium/vscodium/releases/download/${version}${release}/vscodium-reh-${os}-${arch}-${version}${release}.tar.gz';
 
 export async function installCodeServer(
     conn: SSHConnection,


### PR DESCRIPTION
fixes #209 

The fallback value for `serverDownloadUrlTemplate` is working for VSCodium releases prior to 1.99. 
Adapting this value to the new release scheme makes this plugin work out of the box (if you are using VSCodium).