### PR TITLE
feat: exec-chaining for devcontainer on remote ssh

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "open-remote-ssh",
 	"displayName": "Open Remote - SSH",
 	"description": "Use any remote machine with a SSH server as your development environment.",
-	"version": "0.1.3-dev",
+	"version": "0.1.2",
 	"publisher": "jeanp413",
 	"repository": {
 		"type": "git",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "open-remote-ssh",
 	"displayName": "Open Remote - SSH",
 	"description": "Use any remote machine with a SSH server as your development environment.",
-	"version": "0.1.2",
+	"version": "0.1.3-dev",
 	"publisher": "jeanp413",
 	"repository": {
 		"type": "git",

--- a/src/authResolver.ts
+++ b/src/authResolver.ts
@@ -15,6 +15,7 @@ import { untildify, exists as fileExists } from './common/files';
 import { findRandomPort } from './common/ports';
 import { disposeAll } from './common/disposable';
 import { installCodeServer, ServerInstallError, findServerInstallPath } from './serverSetup';
+import { createExecServer } from './execServer';
 import { isWindows } from './common/platform';
 import * as os from 'os';
 import { isNullable } from '@zokugun/is-it-type';
@@ -122,130 +123,139 @@ export class RemoteSSHResolver implements vscode.RemoteAuthorityResolver, vscode
     ) {
     }
 
+    private async establishConnection(authority: string): Promise<{ sshDest: SSHDestination; agentForward: boolean }> {
+        const [, dest] = authority.split('+');
+        const sshDest = SSHDestination.parseEncoded(dest);
+
+        const remoteSSHconfig = vscode.workspace.getConfiguration('remote.SSH');
+        const enableAgentForwarding = remoteSSHconfig.get<boolean>('enableAgentForwarding', true)!;
+        const connectTimeout = remoteSSHconfig.get<number>('connectTimeout', 60)!;
+
+        const sshconfig = await SSHConfiguration.loadFromFS();
+        const sshHostConfig = sshconfig.getHostConfiguration(sshDest.hostname);
+        const sshHostName = sshHostConfig['HostName'] ? sshHostConfig['HostName'].replace('%h', sshDest.hostname) : sshDest.hostname;
+        const sshUser = sshHostConfig['User'] || sshDest.user || os.userInfo().username || '';
+        const sshPort = sshHostConfig['Port'] ? parseInt(sshHostConfig['Port'], 10) : (sshDest.port || 22);
+
+        this.sshAgentSock = sshHostConfig['IdentityAgent'] || process.env['SSH_AUTH_SOCK'] || (isWindows ? '\\\\.\\pipe\\openssh-ssh-agent' : undefined);
+        this.sshAgentSock = this.sshAgentSock ? untildify(this.sshAgentSock) : undefined;
+        const agentForward = enableAgentForwarding && (sshHostConfig['ForwardAgent'] || 'no').toLowerCase() === 'yes';
+        const agent = agentForward && this.sshAgentSock ? new ssh2.OpenSSHAgent(this.sshAgentSock) : undefined;
+
+        const preferredAuthentications = sshHostConfig['PreferredAuthentications'] ? sshHostConfig['PreferredAuthentications'].split(',').map(s => s.trim()) : ['publickey', 'password', 'keyboard-interactive'];
+
+        const identityFiles: string[] = (sshHostConfig['IdentityFile'] as unknown as string[]) || [];
+        const identitiesOnly = (sshHostConfig['IdentitiesOnly'] || 'no').toLowerCase() === 'yes';
+        const identityKeys = await gatherIdentityFiles(identityFiles, this.sshAgentSock, identitiesOnly, this.logger);
+
+        // Create proxy jump connections if any
+        let proxyStream: ssh2.ClientChannel | stream.Duplex | undefined;
+        if (sshHostConfig['ProxyJump']) {
+            const proxyJumps = sshHostConfig['ProxyJump'].split(',').filter(i => !!i.trim())
+                .map(i => {
+                    const proxy = SSHDestination.parse(i);
+                    const proxyHostConfig = sshconfig.getHostConfiguration(proxy.hostname);
+                    return [proxy, proxyHostConfig] as [SSHDestination, Record<string, string>];
+                });
+            for (let i = 0; i < proxyJumps.length; i++) {
+                const [proxy, proxyHostConfig] = proxyJumps[i];
+                const proxyHostName = proxyHostConfig['HostName'] || proxy.hostname;
+                const proxyUser = proxyHostConfig['User'] || proxy.user || sshUser;
+                const proxyPort = proxyHostConfig['Port'] ? parseInt(proxyHostConfig['Port'], 10) : (proxy.port || sshPort);
+
+                const proxyAgentForward = enableAgentForwarding && (proxyHostConfig['ForwardAgent'] || 'no').toLowerCase() === 'yes';
+                const proxyAgent = proxyAgentForward && this.sshAgentSock ? new ssh2.OpenSSHAgent(this.sshAgentSock) : undefined;
+
+                const proxyIdentityFiles: string[] = (proxyHostConfig['IdentityFile'] as unknown as string[]) || [];
+                const proxyIdentitiesOnly = (proxyHostConfig['IdentitiesOnly'] || 'no').toLowerCase() === 'yes';
+                const proxyIdentityKeys = await gatherIdentityFiles(proxyIdentityFiles, this.sshAgentSock, proxyIdentitiesOnly, this.logger);
+
+                const proxyAuthHandler = this.getSSHAuthHandler(proxyUser, proxyHostName, proxyIdentityKeys, preferredAuthentications);
+                const proxyConnection = new SSHConnection({
+                    host: !proxyStream ? proxyHostName : undefined,
+                    port: !proxyStream ? proxyPort : undefined,
+                    sock: proxyStream,
+                    username: proxyUser,
+                    readyTimeout: connectTimeout * 1000,
+                    strictVendor: false,
+                    agentForward: proxyAgentForward,
+                    agent: proxyAgent,
+                    authHandler: (arg0, arg1, arg2) => (proxyAuthHandler(arg0, arg1, arg2), undefined)
+                });
+                this.proxyConnections.push(proxyConnection);
+
+                const nextProxyJump = i < proxyJumps.length - 1 ? proxyJumps[i + 1] : undefined;
+                const destIP = nextProxyJump ? (nextProxyJump[1]['HostName'] || nextProxyJump[0].hostname) : sshHostName;
+                const destPort = nextProxyJump ? ((nextProxyJump[1]['Port'] && parseInt(nextProxyJump[1]['Port'], 10)) || nextProxyJump[0].port || 22) : sshPort;
+                proxyStream = await proxyConnection.forwardOut('127.0.0.1', 0, destIP, destPort);
+            }
+        } else if (sshHostConfig['ProxyCommand']) {
+            let proxyArgs = splitProxyCommand(sshHostConfig['ProxyCommand'] as unknown as string | string[])
+                .map((arg) => arg.replace('%h', sshHostName).replace('%n', sshDest.hostname).replace('%p', sshPort.toString()).replace('%r', sshUser));
+            let proxyCommand = proxyArgs.shift()!;
+
+            let options = {};
+            if (isWindows && /\.(bat|cmd)$/.test(proxyCommand)) {
+                proxyCommand = `"${proxyCommand}"`;
+                proxyArgs = proxyArgs.map((arg) => arg.includes(' ') ? `"${arg}"` : arg);
+                options = { shell: true, windowsHide: true, windowsVerbatimArguments: true };
+            }
+
+            this.logger.trace(`Spawning ProxyCommand: ${proxyCommand} ${proxyArgs.join(' ')}`);
+
+            const child = cp.spawn(proxyCommand, proxyArgs, options);
+            proxyStream = stream.Duplex.from({ readable: child.stdout, writable: child.stdin });
+            this.proxyCommandProcess = child;
+        }
+
+        // Create final ssh connection
+        const sshAuthHandler = this.getSSHAuthHandler(sshUser, sshHostName, identityKeys, preferredAuthentications);
+
+        this.sshConnection = new SSHConnection({
+            host: !proxyStream ? sshHostName : undefined,
+            port: !proxyStream ? sshPort : undefined,
+            sock: proxyStream,
+            username: sshUser,
+            readyTimeout: connectTimeout * 1000,
+            strictVendor: false,
+            agentForward,
+            agent,
+            authHandler: (arg0, arg1, arg2) => (sshAuthHandler(arg0, arg1, arg2), undefined),
+        });
+        await this.sshConnection.connect();
+
+        return { sshDest, agentForward };
+    }
+
     resolve(authority: string, context: vscode.RemoteAuthorityResolverContext): Thenable<vscode.ResolverResult> {
-        const [type, dest] = authority.split('+');
+        const [type] = authority.split('+');
         if (type !== REMOTE_SSH_AUTHORITY) {
             throw new Error(`Invalid authority type for SSH resolver: ${type}`);
         }
 
         this.logger.info(`Resolving ssh remote authority '${authority}' (attempt #${context.resolveAttempt})`);
 
-        const sshDest = SSHDestination.parseEncoded(dest);
-
-        // It looks like default values are not loaded yet when resolving a remote,
-        // so let's hardcode the default values here
         const remoteSSHconfig = vscode.workspace.getConfiguration('remote.SSH');
         const enableDynamicForwarding = remoteSSHconfig.get<boolean>('enableDynamicForwarding', true)!;
-        const enableAgentForwarding = remoteSSHconfig.get<boolean>('enableAgentForwarding', true)!;
         const serverDownloadUrlTemplate = remoteSSHconfig.get<string>('serverDownloadUrlTemplate');
         const serverVersion = remoteSSHconfig.get<ServerVersion>('serverVersion', 'match');
         const defaultExtensions = remoteSSHconfig.get<string[]>('defaultExtensions', []);
         const remotePlatformMap = remoteSSHconfig.get<Record<string, string>>('remotePlatform', {});
         const remoteServerListenOnSocket = remoteSSHconfig.get<boolean>('remoteServerListenOnSocket', false)!;
-        const connectTimeout = remoteSSHconfig.get<number>('connectTimeout', 60)!;
         const serverInstallPathMap = remoteSSHconfig.get<Record<string, string>>('serverInstallPath', {});
 
         return vscode.window.withProgress({
-            title: `Setting up SSH Host ${sshDest.hostname}`,
+            title: `Setting up SSH Host...`,
             location: vscode.ProgressLocation.Notification,
             cancellable: false
         }, async () => {
+            let sshDest: SSHDestination | undefined;
             try {
-                const sshconfig = await SSHConfiguration.loadFromFS();
-                const sshHostConfig = sshconfig.getHostConfiguration(sshDest.hostname);
-                const sshHostName = sshHostConfig['HostName'] ? sshHostConfig['HostName'].replace('%h', sshDest.hostname) : sshDest.hostname;
-                const sshUser = sshHostConfig['User'] || sshDest.user || os.userInfo().username || ''; // https://github.com/openssh/openssh-portable/blob/5ec5504f1d328d5bfa64280cd617c3efec4f78f3/sshconnect.c#L1561-L1562
-                const sshPort = sshHostConfig['Port'] ? parseInt(sshHostConfig['Port'], 10) : (sshDest.port || 22);
-
-                this.sshAgentSock = sshHostConfig['IdentityAgent'] || process.env['SSH_AUTH_SOCK'] || (isWindows ? '\\\\.\\pipe\\openssh-ssh-agent' : undefined);
-                this.sshAgentSock = this.sshAgentSock ? untildify(this.sshAgentSock) : undefined;
-                const agentForward = enableAgentForwarding && (sshHostConfig['ForwardAgent'] || 'no').toLowerCase() === 'yes';
-                const agent = agentForward && this.sshAgentSock ? new ssh2.OpenSSHAgent(this.sshAgentSock) : undefined;
-
-                const preferredAuthentications = sshHostConfig['PreferredAuthentications'] ? sshHostConfig['PreferredAuthentications'].split(',').map(s => s.trim()) : ['publickey', 'password', 'keyboard-interactive'];
-
-                const identityFiles: string[] = (sshHostConfig['IdentityFile'] as unknown as string[]) || [];
-                const identitiesOnly = (sshHostConfig['IdentitiesOnly'] || 'no').toLowerCase() === 'yes';
-                const identityKeys = await gatherIdentityFiles(identityFiles, this.sshAgentSock, identitiesOnly, this.logger);
-
-                // Create proxy jump connections if any
-                let proxyStream: ssh2.ClientChannel | stream.Duplex | undefined;
-                if (sshHostConfig['ProxyJump']) {
-                    const proxyJumps = sshHostConfig['ProxyJump'].split(',').filter(i => !!i.trim())
-                        .map(i => {
-                            const proxy = SSHDestination.parse(i);
-                            const proxyHostConfig = sshconfig.getHostConfiguration(proxy.hostname);
-                            return [proxy, proxyHostConfig] as [SSHDestination, Record<string, string>];
-                        });
-                    for (let i = 0; i < proxyJumps.length; i++) {
-                        const [proxy, proxyHostConfig] = proxyJumps[i];
-                        const proxyHostName = proxyHostConfig['HostName'] || proxy.hostname;
-                        const proxyUser = proxyHostConfig['User'] || proxy.user || sshUser;
-                        const proxyPort = proxyHostConfig['Port'] ? parseInt(proxyHostConfig['Port'], 10) : (proxy.port || sshPort);
-
-                        const proxyAgentForward = enableAgentForwarding && (proxyHostConfig['ForwardAgent'] || 'no').toLowerCase() === 'yes';
-                        const proxyAgent = proxyAgentForward && this.sshAgentSock ? new ssh2.OpenSSHAgent(this.sshAgentSock) : undefined;
-
-                        const proxyIdentityFiles: string[] = (proxyHostConfig['IdentityFile'] as unknown as string[]) || [];
-                        const proxyIdentitiesOnly = (proxyHostConfig['IdentitiesOnly'] || 'no').toLowerCase() === 'yes';
-                        const proxyIdentityKeys = await gatherIdentityFiles(proxyIdentityFiles, this.sshAgentSock, proxyIdentitiesOnly, this.logger);
-
-                        const proxyAuthHandler = this.getSSHAuthHandler(proxyUser, proxyHostName, proxyIdentityKeys, preferredAuthentications);
-                        const proxyConnection = new SSHConnection({
-                            host: !proxyStream ? proxyHostName : undefined,
-                            port: !proxyStream ? proxyPort : undefined,
-                            sock: proxyStream,
-                            username: proxyUser,
-                            readyTimeout: connectTimeout * 1000,
-                            strictVendor: false,
-                            agentForward: proxyAgentForward,
-                            agent: proxyAgent,
-                            authHandler: (arg0, arg1, arg2) => (proxyAuthHandler(arg0, arg1, arg2), undefined)
-                        });
-                        this.proxyConnections.push(proxyConnection);
-
-                        const nextProxyJump = i < proxyJumps.length - 1 ? proxyJumps[i + 1] : undefined;
-                        const destIP = nextProxyJump ? (nextProxyJump[1]['HostName'] || nextProxyJump[0].hostname) : sshHostName;
-                        const destPort = nextProxyJump ? ((nextProxyJump[1]['Port'] && parseInt(nextProxyJump[1]['Port'], 10)) || nextProxyJump[0].port || 22) : sshPort;
-                        proxyStream = await proxyConnection.forwardOut('127.0.0.1', 0, destIP, destPort);
-                    }
-                } else if (sshHostConfig['ProxyCommand']) {
-                    let proxyArgs = splitProxyCommand(sshHostConfig['ProxyCommand'] as unknown as string | string[])
-                        .map((arg) => arg.replace('%h', sshHostName).replace('%n', sshDest.hostname).replace('%p', sshPort.toString()).replace('%r', sshUser));
-                    let proxyCommand = proxyArgs.shift()!;
-
-                    let options = {};
-                    if (isWindows && /\.(bat|cmd)$/.test(proxyCommand)) {
-                        proxyCommand = `"${proxyCommand}"`;
-                        proxyArgs = proxyArgs.map((arg) => arg.includes(' ') ? `"${arg}"` : arg);
-                        options = { shell: true, windowsHide: true, windowsVerbatimArguments: true };
-                    }
-
-                    this.logger.trace(`Spawning ProxyCommand: ${proxyCommand} ${proxyArgs.join(' ')}`);
-
-                    const child = cp.spawn(proxyCommand, proxyArgs, options);
-                    proxyStream = stream.Duplex.from({ readable: child.stdout, writable: child.stdin });
-                    this.proxyCommandProcess = child;
-                }
-
-                // Create final shh connection
-                const sshAuthHandler = this.getSSHAuthHandler(sshUser, sshHostName, identityKeys, preferredAuthentications);
-
-                this.sshConnection = new SSHConnection({
-                    host: !proxyStream ? sshHostName : undefined,
-                    port: !proxyStream ? sshPort : undefined,
-                    sock: proxyStream,
-                    username: sshUser,
-                    readyTimeout: connectTimeout * 1000,
-                    strictVendor: false,
-                    agentForward,
-                    agent,
-                    authHandler: (arg0, arg1, arg2) => (sshAuthHandler(arg0, arg1, arg2), undefined),
-                });
-                await this.sshConnection.connect();
+                const result = await this.establishConnection(authority);
+                sshDest = result.sshDest;
 
                 const envVariables: Record<string, string | null> = {};
-                if (agentForward) {
+                if (result.agentForward) {
                     envVariables['SSH_AUTH_SOCK'] = null;
                 }
 
@@ -253,7 +263,7 @@ export class RemoteSSHResolver implements vscode.RemoteAuthorityResolver, vscode
                 const customInstallPath = findServerInstallPath(sshDest.hostname, serverInstallPathMap);
 
                 const installResult = await installCodeServer(
-                    this.sshConnection,
+                    this.sshConnection!,
                     serverDownloadUrlTemplate,
                     serverVersion,
                     defaultExtensions,
@@ -316,9 +326,10 @@ export class RemoteSSHResolver implements vscode.RemoteAuthorityResolver, vscode
                 if (context.resolveAttempt === 1) {
                     this.logger.show();
 
+                    const hostname = sshDest?.hostname ?? authority;
                     const closeRemote = 'Close Remote';
                     const retry = 'Retry';
-                    const result = await vscode.window.showErrorMessage(`Could not establish connection to "${sshDest.hostname}"`, { modal: true }, closeRemote, retry);
+                    const result = await vscode.window.showErrorMessage(`Could not establish connection to "${hostname}"`, { modal: true }, closeRemote, retry);
                     if (result === closeRemote) {
                         await vscode.commands.executeCommand('workbench.action.remote.close');
                     } else if (result === retry) {
@@ -331,6 +342,32 @@ export class RemoteSSHResolver implements vscode.RemoteAuthorityResolver, vscode
                 } else {
                     throw vscode.RemoteAuthorityResolverError.TemporarilyNotAvailable(e.message);
                 }
+            }
+        });
+    }
+
+    resolveExecServer(authority: string, context: vscode.RemoteAuthorityResolverContext): Thenable<vscode.ExecServer> {
+        this.logger.info(`Resolving exec server for '${authority}' (attempt #${context.resolveAttempt})`);
+
+        return vscode.window.withProgress({
+            title: `Connecting via SSH...`,
+            location: vscode.ProgressLocation.Notification,
+            cancellable: false
+        }, async () => {
+            try {
+                await this.establishConnection(authority);
+                return createExecServer(this.sshConnection!, this.logger);
+            } catch (e: unknown) {
+                this.logger.error(`Error resolving exec server`, e);
+
+                if (context.resolveAttempt === 1) {
+                    this.logger.show();
+                }
+
+                if (!(e instanceof Error)) {
+                    throw vscode.RemoteAuthorityResolverError.NotAvailable(String(e));
+                }
+                throw vscode.RemoteAuthorityResolverError.TemporarilyNotAvailable(e.message);
             }
         });
     }

--- a/src/authResolver.ts
+++ b/src/authResolver.ts
@@ -94,6 +94,11 @@ function splitProxyCommand(value: string | string[]): string[] {
     return out;
 }
 
+export interface SSHConnectionInfo {
+    conn: SSHConnection;
+    agentForward: boolean;
+}
+
 export class RemoteSSHResolver implements vscode.RemoteAuthorityResolver, vscode.Disposable {
 
     private proxyConnections: SSHConnection[] = [];
@@ -113,6 +118,105 @@ export class RemoteSSHResolver implements vscode.RemoteAuthorityResolver, vscode
     ) {
     }
 
+    private async getSSHConnectionInfo(sshDest: SSHDestination): Promise<SSHConnectionInfo> {
+        const remoteSSHconfig = vscode.workspace.getConfiguration('remote.SSH');
+        const enableAgentForwarding = remoteSSHconfig.get<boolean>('enableAgentForwarding', true)!;
+        const connectTimeout = remoteSSHconfig.get<number>('connectTimeout', 60)!;
+
+        const sshconfig = await SSHConfiguration.loadFromFS();
+        const sshHostConfig = sshconfig.getHostConfiguration(sshDest.hostname);
+        const sshHostName = sshHostConfig['HostName'] ? sshHostConfig['HostName'].replace('%h', sshDest.hostname) : sshDest.hostname;
+        const sshUser = sshHostConfig['User'] || sshDest.user || os.userInfo().username || ''; // https://github.com/openssh/openssh-portable/blob/5ec5504f1d328d5bfa64280cd617c3efec4f78f3/sshconnect.c#L1561-L1562
+        const sshPort = sshHostConfig['Port'] ? parseInt(sshHostConfig['Port'], 10) : (sshDest.port || 22);
+
+        this.sshAgentSock = sshHostConfig['IdentityAgent'] || process.env['SSH_AUTH_SOCK'] || (isWindows ? '\\\\.\\pipe\\openssh-ssh-agent' : undefined);
+        this.sshAgentSock = this.sshAgentSock ? untildify(this.sshAgentSock) : undefined;
+        const agentForward = enableAgentForwarding && (sshHostConfig['ForwardAgent'] || 'no').toLowerCase() === 'yes';
+        const agent = agentForward && this.sshAgentSock ? new ssh2.OpenSSHAgent(this.sshAgentSock) : undefined;
+        const preferredAuthentications = sshHostConfig['PreferredAuthentications'] ? sshHostConfig['PreferredAuthentications'].split(',').map(s => s.trim()) : ['publickey', 'password', 'keyboard-interactive'];
+
+        const identityFiles: string[] = (sshHostConfig['IdentityFile'] as unknown as string[]) || [];
+        const identitiesOnly = (sshHostConfig['IdentitiesOnly'] || 'no').toLowerCase() === 'yes';
+        const identityKeys = await gatherIdentityFiles(identityFiles, this.sshAgentSock, identitiesOnly, this.logger);
+
+        // Create proxy jump connections if any
+        let proxyStream: ssh2.ClientChannel | stream.Duplex | undefined;
+        if (sshHostConfig['ProxyJump']) {
+            const proxyJumps = sshHostConfig['ProxyJump'].split(',').filter(i => !!i.trim())
+                .map(i => {
+                    const proxy = SSHDestination.parse(i);
+                    const proxyHostConfig = sshconfig.getHostConfiguration(proxy.hostname);
+                    return [proxy, proxyHostConfig] as [SSHDestination, Record<string, string>];
+                });
+            for (let i = 0; i < proxyJumps.length; i++) {
+                const [proxy, proxyHostConfig] = proxyJumps[i];
+                const proxyHostName = proxyHostConfig['HostName'] || proxy.hostname;
+                const proxyUser = proxyHostConfig['User'] || proxy.user || sshUser;
+                const proxyPort = proxyHostConfig['Port'] ? parseInt(proxyHostConfig['Port'], 10) : (proxy.port || sshPort);
+
+                const proxyAgentForward = enableAgentForwarding && (proxyHostConfig['ForwardAgent'] || 'no').toLowerCase() === 'yes';
+                const proxyAgent = proxyAgentForward && this.sshAgentSock ? new ssh2.OpenSSHAgent(this.sshAgentSock) : undefined;
+
+                const proxyIdentityFiles: string[] = (proxyHostConfig['IdentityFile'] as unknown as string[]) || [];
+                const proxyIdentitiesOnly = (proxyHostConfig['IdentitiesOnly'] || 'no').toLowerCase() === 'yes';
+                const proxyIdentityKeys = await gatherIdentityFiles(proxyIdentityFiles, this.sshAgentSock, proxyIdentitiesOnly, this.logger);
+
+                const proxyAuthHandler = this.getSSHAuthHandler(proxyUser, proxyHostName, proxyIdentityKeys, preferredAuthentications);
+                const proxyConnection = new SSHConnection({
+                    host: !proxyStream ? proxyHostName : undefined,
+                    port: !proxyStream ? proxyPort : undefined,
+                    sock: proxyStream,
+                    username: proxyUser,
+                    readyTimeout: connectTimeout * 1000,
+                    strictVendor: false,
+                    agentForward: proxyAgentForward,
+                    agent: proxyAgent,
+                    authHandler: (arg0, arg1, arg2) => (proxyAuthHandler(arg0, arg1, arg2), undefined)
+                });
+                this.proxyConnections.push(proxyConnection);
+
+                const nextProxyJump = i < proxyJumps.length - 1 ? proxyJumps[i + 1] : undefined;
+                const destIP = nextProxyJump ? (nextProxyJump[1]['HostName'] || nextProxyJump[0].hostname) : sshHostName;
+                const destPort = nextProxyJump ? ((nextProxyJump[1]['Port'] && parseInt(nextProxyJump[1]['Port'], 10)) || nextProxyJump[0].port || 22) : sshPort;
+                proxyStream = await proxyConnection.forwardOut('127.0.0.1', 0, destIP, destPort);
+            }
+        } else if (sshHostConfig['ProxyCommand']) {
+            let proxyArgs = splitProxyCommand(sshHostConfig['ProxyCommand'] as unknown as string | string[])
+                .map((arg) => arg.replace('%h', sshHostName).replace('%n', sshDest.hostname).replace('%p', sshPort.toString()).replace('%r', sshUser));
+            let proxyCommand = proxyArgs.shift()!;
+
+            let options = {};
+            if (isWindows && /\.(bat|cmd)$/.test(proxyCommand)) {
+                proxyCommand = `"${proxyCommand}"`;
+                proxyArgs = proxyArgs.map((arg) => arg.includes(' ') ? `"${arg}"` : arg);
+                options = { shell: true, windowsHide: true, windowsVerbatimArguments: true };
+            }
+
+            this.logger.trace(`Spawning ProxyCommand: ${proxyCommand} ${proxyArgs.join(' ')}`);
+
+            const child = cp.spawn(proxyCommand, proxyArgs, options);
+            proxyStream = stream.Duplex.from({ readable: child.stdout, writable: child.stdin });
+            this.proxyCommandProcess = child;
+        }
+
+        // Create final shh connection
+        const sshAuthHandler = this.getSSHAuthHandler(sshUser, sshHostName, identityKeys, preferredAuthentications);
+
+        const connection = new SSHConnection({
+            host: !proxyStream ? sshHostName : undefined,
+            port: !proxyStream ? sshPort : undefined,
+            sock: proxyStream,
+            username: sshUser,
+            readyTimeout: connectTimeout * 1000,
+            strictVendor: false,
+            agentForward,
+            agent,
+            authHandler: (arg0, arg1, arg2) => (sshAuthHandler(arg0, arg1, arg2), undefined),
+        });
+
+        return { conn: connection, agentForward: agentForward };
+    }
+
     resolve(authority: string, context: vscode.RemoteAuthorityResolverContext): Thenable<vscode.ResolverResult> {
         const [type, dest] = authority.split('+');
         if (type !== REMOTE_SSH_AUTHORITY) {
@@ -127,13 +231,11 @@ export class RemoteSSHResolver implements vscode.RemoteAuthorityResolver, vscode
         // so let's hardcode the default values here
         const remoteSSHconfig = vscode.workspace.getConfiguration('remote.SSH');
         const enableDynamicForwarding = remoteSSHconfig.get<boolean>('enableDynamicForwarding', true)!;
-        const enableAgentForwarding = remoteSSHconfig.get<boolean>('enableAgentForwarding', true)!;
         const serverDownloadUrlTemplate = remoteSSHconfig.get<string>('serverDownloadUrlTemplate');
         const serverVersion = remoteSSHconfig.get<ServerVersion>('serverVersion', 'match');
         const defaultExtensions = remoteSSHconfig.get<string[]>('defaultExtensions', []);
         const remotePlatformMap = remoteSSHconfig.get<Record<string, string>>('remotePlatform', {});
         const remoteServerListenOnSocket = remoteSSHconfig.get<boolean>('remoteServerListenOnSocket', false)!;
-        const connectTimeout = remoteSSHconfig.get<number>('connectTimeout', 60)!;
         const serverInstallPathMap = remoteSSHconfig.get<Record<string, string>>('serverInstallPath', {});
 
         return vscode.window.withProgress({
@@ -142,97 +244,8 @@ export class RemoteSSHResolver implements vscode.RemoteAuthorityResolver, vscode
             cancellable: false
         }, async () => {
             try {
-                const sshconfig = await SSHConfiguration.loadFromFS();
-                const sshHostConfig = sshconfig.getHostConfiguration(sshDest.hostname);
-                const sshHostName = sshHostConfig['HostName'] ? sshHostConfig['HostName'].replace('%h', sshDest.hostname) : sshDest.hostname;
-                const sshUser = sshHostConfig['User'] || sshDest.user || os.userInfo().username || ''; // https://github.com/openssh/openssh-portable/blob/5ec5504f1d328d5bfa64280cd617c3efec4f78f3/sshconnect.c#L1561-L1562
-                const sshPort = sshHostConfig['Port'] ? parseInt(sshHostConfig['Port'], 10) : (sshDest.port || 22);
-
-                this.sshAgentSock = sshHostConfig['IdentityAgent'] || process.env['SSH_AUTH_SOCK'] || (isWindows ? '\\\\.\\pipe\\openssh-ssh-agent' : undefined);
-                this.sshAgentSock = this.sshAgentSock ? untildify(this.sshAgentSock) : undefined;
-                const agentForward = enableAgentForwarding && (sshHostConfig['ForwardAgent'] || 'no').toLowerCase() === 'yes';
-                const agent = agentForward && this.sshAgentSock ? new ssh2.OpenSSHAgent(this.sshAgentSock) : undefined;
-
-                const preferredAuthentications = sshHostConfig['PreferredAuthentications'] ? sshHostConfig['PreferredAuthentications'].split(',').map(s => s.trim()) : ['publickey', 'password', 'keyboard-interactive'];
-
-                const identityFiles: string[] = (sshHostConfig['IdentityFile'] as unknown as string[]) || [];
-                const identitiesOnly = (sshHostConfig['IdentitiesOnly'] || 'no').toLowerCase() === 'yes';
-                const identityKeys = await gatherIdentityFiles(identityFiles, this.sshAgentSock, identitiesOnly, this.logger);
-
-                // Create proxy jump connections if any
-                let proxyStream: ssh2.ClientChannel | stream.Duplex | undefined;
-                if (sshHostConfig['ProxyJump']) {
-                    const proxyJumps = sshHostConfig['ProxyJump'].split(',').filter(i => !!i.trim())
-                        .map(i => {
-                            const proxy = SSHDestination.parse(i);
-                            const proxyHostConfig = sshconfig.getHostConfiguration(proxy.hostname);
-                            return [proxy, proxyHostConfig] as [SSHDestination, Record<string, string>];
-                        });
-                    for (let i = 0; i < proxyJumps.length; i++) {
-                        const [proxy, proxyHostConfig] = proxyJumps[i];
-                        const proxyHostName = proxyHostConfig['HostName'] || proxy.hostname;
-                        const proxyUser = proxyHostConfig['User'] || proxy.user || sshUser;
-                        const proxyPort = proxyHostConfig['Port'] ? parseInt(proxyHostConfig['Port'], 10) : (proxy.port || sshPort);
-
-                        const proxyAgentForward = enableAgentForwarding && (proxyHostConfig['ForwardAgent'] || 'no').toLowerCase() === 'yes';
-                        const proxyAgent = proxyAgentForward && this.sshAgentSock ? new ssh2.OpenSSHAgent(this.sshAgentSock) : undefined;
-
-                        const proxyIdentityFiles: string[] = (proxyHostConfig['IdentityFile'] as unknown as string[]) || [];
-                        const proxyIdentitiesOnly = (proxyHostConfig['IdentitiesOnly'] || 'no').toLowerCase() === 'yes';
-                        const proxyIdentityKeys = await gatherIdentityFiles(proxyIdentityFiles, this.sshAgentSock, proxyIdentitiesOnly, this.logger);
-
-                        const proxyAuthHandler = this.getSSHAuthHandler(proxyUser, proxyHostName, proxyIdentityKeys, preferredAuthentications);
-                        const proxyConnection = new SSHConnection({
-                            host: !proxyStream ? proxyHostName : undefined,
-                            port: !proxyStream ? proxyPort : undefined,
-                            sock: proxyStream,
-                            username: proxyUser,
-                            readyTimeout: connectTimeout * 1000,
-                            strictVendor: false,
-                            agentForward: proxyAgentForward,
-                            agent: proxyAgent,
-                            authHandler: (arg0, arg1, arg2) => (proxyAuthHandler(arg0, arg1, arg2), undefined)
-                        });
-                        this.proxyConnections.push(proxyConnection);
-
-                        const nextProxyJump = i < proxyJumps.length - 1 ? proxyJumps[i + 1] : undefined;
-                        const destIP = nextProxyJump ? (nextProxyJump[1]['HostName'] || nextProxyJump[0].hostname) : sshHostName;
-                        const destPort = nextProxyJump ? ((nextProxyJump[1]['Port'] && parseInt(nextProxyJump[1]['Port'], 10)) || nextProxyJump[0].port || 22) : sshPort;
-                        proxyStream = await proxyConnection.forwardOut('127.0.0.1', 0, destIP, destPort);
-                    }
-                } else if (sshHostConfig['ProxyCommand']) {
-                    let proxyArgs = splitProxyCommand(sshHostConfig['ProxyCommand'] as unknown as string | string[])
-                        .map((arg) => arg.replace('%h', sshHostName).replace('%n', sshDest.hostname).replace('%p', sshPort.toString()).replace('%r', sshUser));
-                    let proxyCommand = proxyArgs.shift()!;
-
-                    let options = {};
-                    if (isWindows && /\.(bat|cmd)$/.test(proxyCommand)) {
-                        proxyCommand = `"${proxyCommand}"`;
-                        proxyArgs = proxyArgs.map((arg) => arg.includes(' ') ? `"${arg}"` : arg);
-                        options = { shell: true, windowsHide: true, windowsVerbatimArguments: true };
-                    }
-
-                    this.logger.trace(`Spawning ProxyCommand: ${proxyCommand} ${proxyArgs.join(' ')}`);
-
-                    const child = cp.spawn(proxyCommand, proxyArgs, options);
-                    proxyStream = stream.Duplex.from({ readable: child.stdout, writable: child.stdin });
-                    this.proxyCommandProcess = child;
-                }
-
-                // Create final shh connection
-                const sshAuthHandler = this.getSSHAuthHandler(sshUser, sshHostName, identityKeys, preferredAuthentications);
-
-                this.sshConnection = new SSHConnection({
-                    host: !proxyStream ? sshHostName : undefined,
-                    port: !proxyStream ? sshPort : undefined,
-                    sock: proxyStream,
-                    username: sshUser,
-                    readyTimeout: connectTimeout * 1000,
-                    strictVendor: false,
-                    agentForward,
-                    agent,
-                    authHandler: (arg0, arg1, arg2) => (sshAuthHandler(arg0, arg1, arg2), undefined),
-                });
+                const {conn: sshConnection, agentForward} = await this.getSSHConnectionInfo(sshDest);
+                this.sshConnection = sshConnection;
                 await this.sshConnection.connect();
 
                 const envVariables: Record<string, string | null> = {};

--- a/src/authResolver.ts
+++ b/src/authResolver.ts
@@ -383,6 +383,9 @@ export class RemoteSSHResolver implements vscode.RemoteAuthorityResolver, vscode
             if (e instanceof Error) {
                 throw vscode.RemoteAuthorityResolverError.TemporarilyNotAvailable(e.message);
             }
+            else {
+                throw vscode.RemoteAuthorityResolverError.NotAvailable('Could not connect to remote');
+            }
         }
     }
 

--- a/src/authResolver.ts
+++ b/src/authResolver.ts
@@ -348,15 +348,42 @@ export class RemoteSSHResolver implements vscode.RemoteAuthorityResolver, vscode
         });
     }
 
-    async resolveExecServer(authority: string, _: vscode.RemoteAuthorityResolverContext): Promise<vscode.ExecServer> {
+    async resolveExecServer(authority: string, context: vscode.RemoteAuthorityResolverContext): Promise<vscode.ExecServer> {
         const [type, dest] = authority.split('+');
+        this.logger.info(`resolveExecServer: ${type} to dest '${dest}', attempt ${context.resolveAttempt}`);
+
         if (type !== REMOTE_SSH_AUTHORITY) {
             throw new Error(`Invalid authority type for SSH resolverExec: ${type}`);
         }
 
         const sshDest = SSHDestination.parseEncoded(dest);
         const connInfo = await this.getSSHConnectionInfo(sshDest);
-        return new SSHExecServer(connInfo, this.logger);
+        this.sshConnection = connInfo.conn;
+
+        try {
+            await connInfo.conn.connect();
+            return SSHExecServer.create(connInfo.conn, this.logger);
+        }
+        catch(e: unknown) {
+            this.logger.error(`Error resolving authority`, e);
+            // Initial connection
+            if (context.resolveAttempt === 1) {
+                this.logger.show();
+
+                const closeRemote = 'Close Remote';
+                const retry = 'Retry';
+                const result = await vscode.window.showErrorMessage(`Could not establish connection to "${sshDest.hostname}"`, { modal: true }, closeRemote, retry);
+                if (result === closeRemote) {
+                    await vscode.commands.executeCommand('workbench.action.remote.close');
+                } else if (result === retry) {
+                    await vscode.commands.executeCommand('workbench.action.reloadWindow');
+                }
+            }
+
+            if (e instanceof Error) {
+                throw vscode.RemoteAuthorityResolverError.TemporarilyNotAvailable(e.message);
+            }
+        }
     }
 
     private openAgentForwardSession(): Promise<string | undefined> {

--- a/src/authResolver.ts
+++ b/src/authResolver.ts
@@ -18,6 +18,7 @@ import { installCodeServer, ServerInstallError, findServerInstallPath } from './
 import { isWindows } from './common/platform';
 import * as os from 'os';
 import { ServerVersion } from './serverConfig';
+import { SSHExecServer } from './execServer';
 
 const PASSWORD_RETRY_COUNT = 3;
 const PASSPHRASE_RETRY_COUNT = 3;
@@ -345,6 +346,17 @@ export class RemoteSSHResolver implements vscode.RemoteAuthorityResolver, vscode
                 }
             }
         });
+    }
+
+    async resolveExecServer(authority: string, _: vscode.RemoteAuthorityResolverContext): Promise<vscode.ExecServer> {
+        const [type, dest] = authority.split('+');
+        if (type !== REMOTE_SSH_AUTHORITY) {
+            throw new Error(`Invalid authority type for SSH resolverExec: ${type}`);
+        }
+
+        const sshDest = SSHDestination.parseEncoded(dest);
+        const connInfo = await this.getSSHConnectionInfo(sshDest);
+        return new SSHExecServer(connInfo, this.logger);
     }
 
     private openAgentForwardSession(): Promise<string | undefined> {

--- a/src/execServer.ts
+++ b/src/execServer.ts
@@ -1,0 +1,282 @@
+import * as vscode from 'vscode';
+import type { ClientChannel, SFTPWrapper } from 'ssh2';
+import type { Stats, FileEntry } from 'ssh2-streams';
+import SSHConnection from './ssh/sshConnection';
+import Log from './common/logger';
+
+const S_IFMT = 0o170000;
+const S_IFDIR = 0o040000;
+const S_IFLNK = 0o120000;
+
+// TODO: probs a can of worms, clean up
+function shellEscape(arg: string): string {
+	if (/^[a-zA-Z0-9._\-/=:@,+]+$/.test(arg)) {return arg;}
+	return '\'' + arg.replace(/'/g, '\'\\\'\'') + '\'';
+}
+
+function buildCommand(command: string, args: string[], options?: vscode.ExecServerSpawnOptions): string {
+	let cmd = '';
+	if (options?.cwd) {
+		cmd += `cd ${shellEscape(options.cwd)} && `;
+	}
+	if (options?.env) {
+		for (const [key, value] of Object.entries(options.env)) {
+			cmd += `${key}=${shellEscape(value)} `;
+		}
+	}
+	cmd += shellEscape(command);
+	for (const arg of args) {
+		cmd += ' ' + shellEscape(arg);
+	}
+	return cmd;
+}
+
+function nodeReadableToReadStream(readable: NodeJS.ReadableStream): vscode.ReadStream {
+	const emitter = new vscode.EventEmitter<Uint8Array>();
+	const onEnd = new Promise<void>((resolve) => {
+		readable.on('data', (chunk: Buffer) => emitter.fire(new Uint8Array(chunk)));
+		readable.on('end', () => { resolve(); emitter.dispose(); });
+		readable.on('error', () => { resolve(); emitter.dispose(); });
+	});
+	return { onDidReceiveMessage: emitter.event, onEnd };
+}
+
+function wrapDuplexChannel(channel: ClientChannel): { stream: vscode.WriteStream & vscode.ReadStream; done: Thenable<void> } {
+	const emitter = new vscode.EventEmitter<Uint8Array>();
+	let resolved = false;
+	const done = new Promise<void>((resolve) => {
+		const finish = () => { if (!resolved) { resolved = true; resolve(); emitter.dispose(); } };
+		channel.on('end', finish);
+		channel.on('close', finish);
+		channel.on('error', finish);
+	});
+	channel.on('data', (chunk: Buffer) => emitter.fire(new Uint8Array(chunk)));
+	return {
+		stream: {
+			onDidReceiveMessage: emitter.event,
+			onEnd: done,
+			write(data: Uint8Array) { channel.write(Buffer.from(data)); },
+			end() { channel.end(); }
+		},
+		done
+	};
+}
+
+function fileTypeFromMode(mode: number): vscode.FileType {
+	const fmt = mode & S_IFMT;
+	if (fmt === S_IFDIR) {return vscode.FileType.Directory;}
+	if (fmt === S_IFLNK) {return vscode.FileType.SymbolicLink;}
+	return vscode.FileType.File;
+}
+
+export function createExecServer(conn: SSHConnection, logger: Log): vscode.ExecServer {
+	let sftpClient: SFTPWrapper | undefined;
+
+	async function getSftp(): Promise<SFTPWrapper> {
+		if (sftpClient) {return sftpClient;}
+		const client = conn.getClient();
+		if (!client) {throw new Error('SSH connection not available');}
+		return new Promise((resolve, reject) => {
+			client.sftp((err, sftp) => {
+				if (err) {return reject(err);}
+				sftpClient = sftp;
+				resolve(sftp);
+			});
+		});
+	}
+
+	return {
+		async spawn(command: string, args: string[], options?: vscode.ExecServerSpawnOptions): Promise<vscode.SpawnedCommand> {
+			const cmd = buildCommand(command, args, options);
+			logger.trace(`ExecServer.spawn: ${cmd}`);
+			const channel = await conn.execChannel(cmd);
+
+			return {
+				stdin: {
+					write(data: Uint8Array) { channel.write(Buffer.from(data)); },
+					end() { channel.end(); }
+				},
+				stdout: nodeReadableToReadStream(channel),
+				stderr: nodeReadableToReadStream(channel.stderr),
+				onExit: new Promise<vscode.ProcessExit>((resolve) => {
+					let done = false;
+					channel.on('exit', (code: number | null, signal?: string) => {
+						if (!done) { done = true; resolve({ status: code ?? (signal ? 128 : 0) }); }
+					});
+					channel.on('close', () => {
+						if (!done) { done = true; resolve({ status: 1 }); }
+					});
+				})
+			};
+		},
+
+		async env(): Promise<vscode.ExecEnvironment> {
+			const { stdout: envOut } = await conn.exec('env -0 2>/dev/null || env');
+			const env: Record<string, string> = {};
+			const separator = envOut.includes('\0') ? '\0' : '\n';
+			for (const entry of envOut.split(separator)) {
+				const eqIdx = entry.indexOf('=');
+				if (eqIdx > 0) {
+					env[entry.substring(0, eqIdx)] = entry.substring(eqIdx + 1);
+				}
+			}
+
+			const { stdout: unameOut } = await conn.exec('uname -s');
+			const kernel = unameOut.trim();
+			const osPlatform = kernel === 'Darwin' ? 'darwin'
+				: (kernel.startsWith('MINGW') || kernel.startsWith('MSYS')) ? 'win32'
+				: 'linux';
+
+			let osRelease: string | undefined;
+			try {
+				const { stdout: releaseOut } = await conn.exec('uname -r');
+				osRelease = releaseOut.trim() || undefined;
+			} catch { /* ignore */ }
+
+			return { env, osPlatform, osRelease };
+		},
+
+		async kill(processId: number): Promise<void> {
+			logger.trace(`ExecServer.kill: ${processId}`);
+			await conn.exec(`kill ${processId}`);
+		},
+
+		async tcpConnect(host: string, port: number): Promise<{ stream: vscode.WriteStream & vscode.ReadStream; done: Thenable<void> }> {
+			logger.trace(`ExecServer.tcpConnect: ${host}:${port}`);
+			const channel = await conn.forwardOut('127.0.0.1', 0, host, port);
+			return wrapDuplexChannel(channel);
+		},
+
+		fs: {
+			async stat(remotePath: string): Promise<vscode.FileStat> {
+				const sftp = await getSftp();
+				return new Promise((resolve, reject) => {
+					sftp.lstat(remotePath, (err: any, stats: Stats) => {
+						if (err) {return reject(err);}
+						resolve({
+							type: stats.isDirectory() ? vscode.FileType.Directory
+								: stats.isSymbolicLink() ? vscode.FileType.SymbolicLink
+								: vscode.FileType.File,
+							ctime: (stats.atime ?? stats.mtime ?? 0) * 1000,
+							mtime: (stats.mtime ?? 0) * 1000,
+							size: stats.size ?? 0
+						});
+					});
+				});
+			},
+
+			async mkdirp(remotePath: string): Promise<void> {
+				const sftp = await getSftp();
+				const segments: string[] = [];
+				let dir = remotePath;
+				// Walk up until we find a directory that exists
+				for (;;) {
+					const exists = await new Promise<boolean>((resolve) => {
+						sftp.stat(dir, (err) => resolve(!err));
+					});
+					if (exists) {break;}
+					segments.push(dir);
+					const parent = dir.substring(0, dir.lastIndexOf('/')) || '/';
+					if (parent === dir) {break;}
+					dir = parent;
+				}
+				// Create directories top-down
+				for (let i = segments.length - 1; i >= 0; i--) {
+					await new Promise<void>((resolve, reject) => {
+						sftp.mkdir(segments[i], (err) => {
+							if (err) {reject(err);}
+							else {resolve();}
+						});
+					});
+				}
+			},
+
+			async rm(remotePath: string): Promise<void> {
+				const sftp = await getSftp();
+				async function rmRecursive(p: string): Promise<void> {
+					const stats = await new Promise<Stats>((resolve, reject) => {
+						sftp.lstat(p, (err, s) => err ? reject(err) : resolve(s));
+					});
+					if (stats.isDirectory()) {
+						const entries = await new Promise<FileEntry[]>((resolve, reject) => {
+							sftp.readdir(p, (err, list) => err ? reject(err) : resolve(list));
+						});
+						for (const entry of entries) {
+							await rmRecursive(p + '/' + entry.filename);
+						}
+						await new Promise<void>((resolve, reject) => {
+							sftp.rmdir(p, (err) => err ? reject(err) : resolve());
+						});
+					} else {
+						await new Promise<void>((resolve, reject) => {
+							sftp.unlink(p, (err) => err ? reject(err) : resolve());
+						});
+					}
+				}
+				try {
+					await rmRecursive(remotePath);
+				} catch (err: any) {
+					if (err?.code === 2) {return;} // ENOENT — already gone
+					throw err;
+				}
+			},
+
+			async read(remotePath: string): Promise<vscode.ReadStream> {
+				const sftp = await getSftp();
+				const readable = sftp.createReadStream(remotePath);
+				return nodeReadableToReadStream(readable);
+			},
+
+			async write(remotePath: string): Promise<{ stream: vscode.WriteStream; done: Thenable<void> }> {
+				const sftp = await getSftp();
+				const writable = sftp.createWriteStream(remotePath);
+				const writeDone = new Promise<void>((resolve, reject) => {
+					writable.on('close', resolve);
+					writable.on('error', reject);
+				});
+				return {
+					stream: {
+						write(data: Uint8Array) { writable.write(Buffer.from(data)); },
+						end() { writable.end(); }
+					},
+					done: writeDone
+				};
+			},
+
+			async connect(socketPath: string): Promise<{ stream: vscode.WriteStream & vscode.ReadStream; done: Thenable<void> }> {
+				const client = conn.getClient();
+				if (!client) {throw new Error('SSH connection not available');}
+				const channel = await new Promise<ClientChannel>((resolve, reject) => {
+					client.openssh_forwardOutStreamLocal(socketPath, (err, stream) => {
+						if (err) {reject(err);}
+						else {resolve(stream);}
+					});
+				});
+				return wrapDuplexChannel(channel);
+			},
+
+			async rename(fromPath: string, toPath: string): Promise<void> {
+				const sftp = await getSftp();
+				return new Promise((resolve, reject) => {
+					sftp.rename(fromPath, toPath, (err: any) => {
+						if (err) {return reject(err);}
+						resolve();
+					});
+				});
+			},
+
+			async readdir(remotePath: string): Promise<vscode.DirectoryEntry[]> {
+				const sftp = await getSftp();
+				return new Promise((resolve, reject) => {
+					sftp.readdir(remotePath, (err: any, list: FileEntry[]) => {
+						if (err) {return reject(err);}
+						resolve(list.map(item => ({
+							name: item.filename,
+							type: fileTypeFromMode(item.attrs.mode)
+						})));
+					});
+				});
+			}
+		}
+	};
+}

--- a/src/execServer.ts
+++ b/src/execServer.ts
@@ -28,7 +28,7 @@ export function shellEscaped(cmd: string, args: string[], options?: vscode.ExecS
     if (options?.env) {
         const envStr = Object.entries(options.env)
             .map(([k, v]) => {
-                if (ENV_KEY_REGEX.test(k) ===  false) {
+                if (ENV_KEY_REGEX.test(k) === false) {
                     throw new Error(`Bad env key: '${k}'`);
                 }
                 return `${k}=${shellEscapeArg(v)}`;
@@ -90,18 +90,20 @@ function toReadWriteStream(stream: Stream.Duplex, logger: Log): ReadWriteStream 
     };
 }
 
-function getFileType(mode: number) {
+export function getFileType(mode: number) {
     const S_IFMT = 0o0170000;  // bit mask for the file type bit field
     enum modes {
         S_IFDIR = 0o0040000, // directory
         S_IFREG = 0o0100000, // regular file
         S_IFLNK = 0o0120000, // symbolic link
+        S_IFSOCK = 0o140000,  // socket
     }
-    const ftype = mode & S_IFMT;
-    if ((ftype & modes.S_IFDIR) === modes.S_IFDIR) { return vscode.FileType.Directory; }
-    else if ((ftype & modes.S_IFLNK) === modes.S_IFLNK) { return vscode.FileType.SymbolicLink; }
-    else if ((ftype & modes.S_IFREG) === modes.S_IFREG) { return vscode.FileType.File; }
-    else { return vscode.FileType.Unknown; }
+    const fmode = mode & S_IFMT;
+
+    if (fmode === modes.S_IFLNK) { return vscode.FileType.SymbolicLink; }
+    else if (fmode === modes.S_IFREG) { return vscode.FileType.File; }
+    else if (fmode === modes.S_IFDIR) { return vscode.FileType.Directory; }
+    return vscode.FileType.Unknown;
 }
 
 export class SSHExecServerFileSystem implements vscode.RemoteFileSystem, vscode.Disposable {
@@ -159,8 +161,8 @@ export class SSHExecServerFileSystem implements vscode.RemoteFileSystem, vscode.
             for (const segment of segments.reverse()) {
                 await new Promise<void>((resolve, reject) => {
                     this.sftp.mkdir(segment, (err) => {
-                        if (err) {reject(err);}
-                        else {resolve();}
+                        if (err) { reject(err); }
+                        else { resolve(); }
                     });
                 });
             }
@@ -204,16 +206,16 @@ export class SSHExecServerFileSystem implements vscode.RemoteFileSystem, vscode.
 
         return new Promise((resolve, reject) => {
             this.conn.getClient().openssh_forwardOutStreamLocal(sockPath, (err: Error | undefined, chan: ClientChannel) => {
-                if (err) {return reject(err);}
+                if (err) { return reject(err); }
 
                 resolve({
                     stream: toReadWriteStream(chan, this.logger),
                     done: new Promise((res, rej) => {
                         chan.on('close', () => res());
                         chan.on('exit', (exitCode: number | null, signalName?: string, didCoreDump?: boolean, description?: string) => {
-                            if (exitCode === 0) return res();
+                            if (exitCode === 0) { return res(); }
 
-                            void(didCoreDump);
+                            void (didCoreDump);
                             this.logger.error(`SFTP.connect: error: exitCode=${exitCode}, signalName=${signalName}, description=${description}`);
                             rej({ status: exitCode ?? (signalName ? 128 : 0) });
                         });
@@ -391,9 +393,9 @@ export class SSHExecServer implements vscode.ExecServer, vscode.Disposable {
             done: new Promise((resolve, reject) => {
                 chan.on('close', () => resolve());
                 chan.on('exit', (exitCode: number | null, signalName?: string, didCoreDump?: boolean, description?: string) => {
-                    if (exitCode === 0) return resolve();
+                    if (exitCode === 0) { return resolve(); }
 
-                    void(didCoreDump);
+                    void (didCoreDump);
                     this.logger.error(`SSHExecServer.tcpConnect: error: exitCode=${exitCode}, signalName=${signalName}, description=${description}`);
                     reject({ status: exitCode ?? (signalName ? 128 : 0) });
                 });

--- a/src/execServer.ts
+++ b/src/execServer.ts
@@ -1,0 +1,35 @@
+import * as vscode from 'vscode';
+
+export class SSHExecServer implements vscode.ExecServer, vscode.Disposable {
+    fs: vscode.RemoteFileSystem;
+
+    public constructor() { }
+
+    public spawn(command: string, args: string[], options?: vscode.ExecServerSpawnOptions): Thenable<vscode.SpawnedCommand> {
+        throw new Error('Method not implemented.');
+    }
+
+    public spawnRemoteServerConnector?(command: string, args: string[], options?: vscode.ExecServerSpawnOptions): Thenable<vscode.RemoteServerConnector> {
+        throw new Error('Method not implemented.');
+    }
+
+    public downloadCliExecutable?(buildTarget: vscode.CliBuild, command: string, args: string[], options?: vscode.ExecServerSpawnOptions): Thenable<vscode.ProcessExit> {
+        throw new Error('Method not implemented.');
+    }
+
+    public env(): Thenable<vscode.ExecEnvironment> {
+        throw new Error('Method not implemented.');
+    }
+
+    public kill(processId: number): Thenable<void> {
+        throw new Error('Method not implemented.');
+    }
+
+    public tcpConnect(host: string, port: number): Thenable<{ stream: vscode.WriteStream & vscode.ReadStream; done: Thenable<void> }> {
+        throw new Error('Method not implemented.');
+    }
+
+    public dispose() {
+        throw new Error('Method not implemented.');
+    }
+}

--- a/src/execServer.ts
+++ b/src/execServer.ts
@@ -1,87 +1,408 @@
 import * as vscode from 'vscode';
-import { Log } from './common/logger';
-import { SFTPWrapper } from 'ssh2';
+import path from 'node:path';
+import Stream from 'node:stream';
+
+import { SFTPWrapper, ExecOptions, ClientChannel } from 'ssh2';
+import { FileEntry, Stats } from 'ssh2-streams';
+
 import SSHConnection from './ssh/sshConnection';
+import { Log } from './common/logger';
+
+let CMD_INX = 0;
+
+type ReadWriteStream = vscode.ReadStream & vscode.WriteStream;
+
+export function shellEscapeArg(arg: string) {
+    // eslint-disable-next-line @stylistic/quotes
+    return "'" + arg.replace(/'/g, "'\\''") + "'";
+}
+
+function formatError(err: Error) {
+    return `name=${err.name}, message=${err.message}, stack=${err.stack}`;
+}
+
+export function shellEscaped(cmd: string, args: string[], options?: vscode.ExecServerSpawnOptions): string {
+    const ENV_KEY_REGEX = /^[A-Za-z_][A-Za-z_0-9]*$/;
+
+    let stringCmd = [cmd, ...args].map(e => shellEscapeArg(e)).join(' ');
+    if (options?.env) {
+        const envStr = Object.entries(options.env)
+            .map(([k, v]) => {
+                if (ENV_KEY_REGEX.test(k) ===  false) {
+                    throw new Error(`Bad env key: '${k}'`);
+                }
+                return `${k}=${shellEscapeArg(v)}`;
+            })
+            .join(' ');
+
+        stringCmd = `${envStr} ${stringCmd}`;
+    }
+
+    // must be after adding env
+    if (options?.cwd) {
+        stringCmd = `cd ${shellEscapeArg(options.cwd)} && ${stringCmd}`;
+    }
+
+    return stringCmd;
+}
+
+function toReadStream(stream: Stream.Readable, logger: Log): vscode.ReadStream {
+    const emitter = new vscode.EventEmitter<Uint8Array>();
+
+    stream.on('data', (str: Buffer) => { emitter.fire(str); });
+
+    return {
+        onDidReceiveMessage: emitter.event,
+        onEnd: new Promise<void>((resolve, reject) => {
+            stream.on('end', () => {
+                resolve();
+                emitter.dispose();
+            });
+            stream.on('error', (err: Error) => {
+                logger.error(`toReadStream error: ${formatError(err)}`);
+                emitter.dispose();
+                reject(err);
+            });
+        }),
+    };
+}
+
+function toReadWriteStream(stream: Stream.Duplex, logger: Log): ReadWriteStream {
+    const emitter = new vscode.EventEmitter<Uint8Array>();
+
+    stream.on('data', (str: Buffer) => { emitter.fire(str); });
+
+    return {
+        onDidReceiveMessage: emitter.event,
+        onEnd: new Promise<void>((resolve, reject) => {
+            stream.on('end', () => {
+                resolve();
+                emitter.dispose();
+            });
+            stream.on('error', (err: Error) => {
+                logger.error(`toReadWriteStream error: ${formatError(err)}`);
+                emitter.dispose();
+                reject(err);
+            });
+        }),
+        write(data: Uint8Array) { stream.write(data); },
+        end() { stream.end(); }
+    };
+}
+
+function getFileType(mode: number) {
+    const S_IFMT = 0o0170000;  // bit mask for the file type bit field
+    enum modes {
+        S_IFDIR = 0o0040000, // directory
+        S_IFREG = 0o0100000, // regular file
+        S_IFLNK = 0o0120000, // symbolic link
+    }
+    const ftype = mode & S_IFMT;
+    if ((ftype & modes.S_IFDIR) === modes.S_IFDIR) { return vscode.FileType.Directory; }
+    else if ((ftype & modes.S_IFLNK) === modes.S_IFLNK) { return vscode.FileType.SymbolicLink; }
+    else if ((ftype & modes.S_IFREG) === modes.S_IFREG) { return vscode.FileType.File; }
+    else { return vscode.FileType.Unknown; }
+}
 
 export class SSHExecServerFileSystem implements vscode.RemoteFileSystem, vscode.Disposable {
     public constructor(
+        private readonly conn: SSHConnection,
         private readonly sftp: SFTPWrapper,
         private readonly logger: Log
     ) {
     }
 
-    public stat(path: string): Thenable<vscode.FileStat> {
-        throw new Error("Method 'stat' not implemented.");
+    public stat(path: string): Promise<vscode.FileStat> {
+        return new Promise((resolve, reject) => {
+            this.sftp.lstat(path, (err: Error, stats: Stats) => {
+                if (err) {
+                    this.logger.error(`SFTP: stat('${path}'): ${formatError(err)}`);
+                    reject(err);
+                }
+                else {
+                    const ret: vscode.FileStat = {
+                        type: stats.isDirectory() ? vscode.FileType.Directory
+                            : stats.isSymbolicLink() ? vscode.FileType.SymbolicLink
+                                : stats.isFile() ? vscode.FileType.File : vscode.FileType.Unknown,
+                        ctime: stats.mtime * 1000, // no ctime in stats
+                        mtime: stats.mtime * 1000,
+                        size: stats.size,
+                        permissions: ((stats.mode & 0o222) === 0) ? vscode.FilePermission.Readonly : undefined,
+                    };
+                    this.logger.info(`SFTP: stat('${path}'): ${JSON.stringify(ret)}`);
+                    resolve(ret);
+                }
+            });
+        });
     }
 
-    public mkdirp(path: string): Thenable<void> {
-        throw new Error("Method 'mkdirp' not implemented.");
+    public async mkdirp(dirPath: string): Promise<void> {
+        this.logger.info(`SFTP: mkdirp('${dirPath}')`);
+        const segments: string[] = [];
+        let dir = dirPath;
+
+        try {
+            while (true) {
+                try {
+                    await this.stat(dir);
+                    break;
+                }
+                catch { /* dir doesn't exist */ }
+
+                segments.push(dir);
+                const parent = path.posix.dirname(dir);
+
+                if (parent === dir) { break; }
+                dir = parent;
+            }
+
+            for (const segment of segments.reverse()) {
+                await new Promise<void>((resolve, reject) => {
+                    this.sftp.mkdir(segment, (err) => {
+                        if (err) {reject(err);}
+                        else {resolve();}
+                    });
+                });
+            }
+        }
+        catch (err: unknown) {
+            if (err instanceof Error) {
+                this.logger.error(`SFTP: mkdirp('${dirPath}') failed: ${formatError(err as Error)}`);
+            }
+            throw err;
+        }
     }
 
-    public rm(path: string): Thenable<void> {
-        throw new Error("Method 'rm' not implemented.");
+    public rm(path: string): Promise<void> {
+        this.logger.info(`SFTP: rm('${path}')`);
+        throw new Error('Method "rm" not implemented.');
     }
 
-    public read(path: string): Thenable<vscode.ReadStream> {
-        throw new Error("Method 'read' not implemented.");
+    public async read(path: string): Promise<vscode.ReadStream> {
+        this.logger.info(`SFTP: read('${path}')`);
+        return toReadStream(this.sftp.createReadStream(path), this.logger);
     }
 
-    public write(path: string): Thenable<{ stream: vscode.WriteStream; done: Thenable<void>; }> {
-        throw new Error("Method 'write' not implemented.");
+    public async write(path: string): Promise<{ stream: vscode.WriteStream; done: Promise<void> }> {
+        this.logger.info(`SFTP: write('${path}')`);
+        const writeStream = this.sftp.createWriteStream(path);
+
+        return {
+            stream: {
+                write: (data: Uint8Array) => { writeStream.write(data); },
+                end: () => { writeStream.end(); },
+            },
+            done: new Promise<void>((resolve, reject) => {
+                writeStream.on('close', () => { resolve(); });
+                writeStream.on('error', (err: Error) => { reject(err); });
+            })
+        };
     }
 
-    public connect(path: string): Thenable<{ stream: vscode.WriteStream & vscode.ReadStream; done: Thenable<void>; }> {
-        throw new Error("Method 'connect' not implemented.");
+    public connect(sockPath: string): Promise<{ stream: vscode.WriteStream & vscode.ReadStream; done: Promise<void> }> {
+        this.logger.info(`SFTP: connect('${sockPath}')`);
+
+        return new Promise((resolve, reject) => {
+            this.conn.getClient().openssh_forwardOutStreamLocal(sockPath, (err: Error | undefined, chan: ClientChannel) => {
+                if (err) {return reject(err);}
+
+                resolve({
+                    stream: toReadWriteStream(chan, this.logger),
+                    done: new Promise((res, rej) => {
+                        chan.on('close', () => res());
+                        chan.on('exit', (exitCode: number | null, signalName?: string, didCoreDump?: boolean, description?: string) => {
+                            if (exitCode === 0) return res();
+
+                            void(didCoreDump);
+                            this.logger.error(`SFTP.connect: error: exitCode=${exitCode}, signalName=${signalName}, description=${description}`);
+                            rej({ status: exitCode ?? (signalName ? 128 : 0) });
+                        });
+                    }),
+                });
+            });
+        });
     }
 
-    public rename(fromPath: string, toPath: string): Thenable<void> {
-        throw new Error("Method 'rename' not implemented.");
+    public rename(fromPath: string, toPath: string): Promise<void> {
+        return new Promise((resolve, reject) => {
+            this.sftp.rename(fromPath, toPath, (err: Error) => {
+                if (err) {
+                    this.logger.error(`SFTP: rename(fromPath: '${fromPath}', toPath: '${toPath}'): ${formatError(err)}`);
+                    reject(err);
+                }
+                else {
+                    this.logger.info(`SFTP: rename(fromPath: '${fromPath}', toPath: '${toPath}'): OK`);
+                    resolve();
+                }
+            });
+        });
     }
 
-    public readdir(path: string): Thenable<vscode.DirectoryEntry[]> {
-        throw new Error("Method 'readdir' not implemented.");
+    public readdir(path: string): Promise<vscode.DirectoryEntry[]> {
+        return new Promise((resolve, reject) => {
+            this.sftp.readdir(path, (err: Error, fileList: FileEntry[]) => {
+                if (err) {
+                    this.logger.error(`SFTP: readdir('${path}'): ${formatError(err)}`);
+                    reject(err);
+                }
+                else {
+                    this.logger.info(`SFTP: readdir('${path}'): ${JSON.stringify(fileList)}`);
+                    const ret: vscode.DirectoryEntry[] = fileList.map(e => {
+                        return {
+                            type: getFileType(e.attrs.mode),
+                            name: e.filename,
+                        };
+                    });
+                    resolve(ret);
+                }
+            });
+        });
     }
 
     public dispose() {
-        throw new Error("Method 'dispose' not implemented.");
+        this.sftp.end();
     }
 }
 
 export class SSHExecServer implements vscode.ExecServer, vscode.Disposable {
-    fs: SSHExecServerFileSystem;
-
-    public constructor(
+    private constructor(
         private readonly conn: SSHConnection,
-        private readonly logger: Log
+        public readonly fs: SSHExecServerFileSystem,
+        private readonly logger: Log,
     ) {
-        this.fs = new SSHExecServerFileSystem(conn, logger);
     }
 
-    public spawn(command: string, args: string[], options?: vscode.ExecServerSpawnOptions): Thenable<vscode.SpawnedCommand> {
-        throw new Error("Method not implemented.");
+    private exec(cmd: string, args: string[], opts?: ExecOptions): Promise<{ stdout: string; stderr: string }> {
+        this.logger.info(`SSHExecServer.exec(cmd: ${cmd}, args: [${args.join(', ')}], opts: ${JSON.stringify(opts)})`);
+        return this.conn.exec(cmd, args, opts);
     }
 
-    public spawnRemoteServerConnector?(command: string, args: string[], options?: vscode.ExecServerSpawnOptions): Thenable<vscode.RemoteServerConnector> {
-        throw new Error("Method not implemented.");
+    public static async create(conn: SSHConnection, logger: Log) {
+        logger.info('creating SSHExecServer...');
+        const sftp = await conn.createSftp();
+        const fs = new SSHExecServerFileSystem(conn, sftp, logger);
+        return new SSHExecServer(conn, fs, logger);
     }
 
-    public downloadCliExecutable?(buildTarget: vscode.CliBuild, command: string, args: string[], options?: vscode.ExecServerSpawnOptions): Thenable<vscode.ProcessExit> {
-        throw new Error("Method not implemented.");
+    public async spawn(command: string, args: string[], options?: vscode.ExecServerSpawnOptions): Promise<vscode.SpawnedCommand> {
+        const cmdInx = ++CMD_INX;
+        const cmd = shellEscaped(command, args, options);
+        this.logger.info(`SSHExecServer.spawn [${cmdInx}]: [${command}, ${args.join(', ')}] => '${cmd}'`);
+        const channel = await this.conn.execChannel(cmd, {});
+
+        return {
+            stdin: {
+                write(data: Uint8Array) { channel.stdin.write(data); },
+                end() { channel.stdin.end(); }
+            },
+            stdout: toReadStream(channel.stdout, this.logger),
+            stderr: toReadStream(channel.stderr, this.logger),
+            onExit: new Promise((resolve) => {
+                let cmdExit = false;
+                channel.on('exit', (exitCode: number | null, signalName?: string, _didCoreDump?: boolean, description?: string) => {
+                    cmdExit = true;
+                    if (exitCode === 0) {
+                        this.logger.info(`SSHExecServer.spawn [${cmdInx}]: OK: ${cmd}`);
+                        resolve({ status: 0 });
+                    }
+                    else {
+                        this.logger.error(`SSHExecServer.spawn [${cmdInx}]: error: exitCode=${exitCode}, signalName=${signalName}, description=${description}`);
+                        resolve({ status: exitCode ?? (signalName ? 128 : 0) });
+                    }
+                });
+                channel.on('close', () => {
+                    if (!cmdExit) {
+                        this.logger.error(`SSHExecServer.spawn [${cmdInx}]: channel "${cmd}" was closed`);
+                        resolve({ status: 1 });
+                    }
+                });
+            }),
+        };
     }
 
-    public env(): Thenable<vscode.ExecEnvironment> {
-        throw new Error("Method not implemented.");
+    public async env(): Promise<vscode.ExecEnvironment> {
+        // TODO: mac and windows support
+        this.logger.info('SSHExecServer.env()');
+        try {
+            const envs: Record<string, string> = {};
+            let osPlatform: string | undefined;
+            let osVer: string | undefined;
+
+            {
+                const { stdout: envStdout, stderr: envStderr } = await this.exec('env', ['-0']);
+
+                if (envStderr) { this.logger.error(`Remote env probe stderr: '${envStderr}'`); }
+
+                for (const entry of envStdout.split('\0')) {
+                    // .trim does not trim '\0'
+                    if (!entry) { continue; }
+                    const eqInx = entry.indexOf('=');
+
+                    // shouldn't happen
+                    if (eqInx <= 0) { continue; }
+
+                    const [k, v] = [entry.slice(0, eqInx), entry.slice(eqInx + 1)];
+                    envs[k] = v;
+                }
+            }
+
+            {
+                const { stdout: unameSysStdout, stderr: unameSysStderr } = await this.exec('uname', ['-s']);
+                const plat = unameSysStdout.trim().toLowerCase();
+                if (plat === 'linux' || plat === 'darwin') {
+                    osPlatform = plat;
+                }
+                else {
+                    throw new Error(`Unsupported platform ${plat}`);
+                }
+
+                if (unameSysStderr) { this.logger.error(`Remote 'uname -s' probe stderr: '${unameSysStderr}'`); }
+            }
+
+            {
+                const { stdout: unameVerStdout, stderr: unameVerStderr } = await this.exec('uname', ['-r']);
+                const ver = unameVerStdout.trim().toLowerCase();
+                osVer = ver;
+
+                if (unameVerStderr) { this.logger.error(`Remote 'uname -r' probe stderr: '${unameVerStderr}'`); }
+            }
+
+            return { env: envs, osPlatform: osPlatform, osRelease: osVer };
+        }
+        catch (ex: unknown) {
+            if (ex instanceof Error) {
+                const err = `SSHExecServer.env(): Could not query remote env. Is remote windows? ${formatError(ex as Error)}`;
+                this.logger.error(err);
+            }
+            throw ex;
+        }
     }
 
-    public kill(processId: number): Thenable<void> {
-        throw new Error("Method not implemented.");
+    public async kill(processId: number): Promise<void> {
+        await this.exec('kill', [`${processId}`]);
+        return;
     }
 
-    public tcpConnect(host: string, port: number): Thenable<{ stream: vscode.WriteStream & vscode.ReadStream; done: Thenable<void> }> {
-        throw new Error("Method not implemented.");
+    public async tcpConnect(host: string, port: number): Promise<{ stream: ReadWriteStream; done: Promise<void> }> {
+        this.logger.info(`SSHExecServer.tcpConnect(host: ${host}, port: ${port})`);
+        const chan = await this.conn.forwardOut('127.0.0.1', 0, host, port);
+        return {
+            stream: toReadWriteStream(chan, this.logger),
+            done: new Promise((resolve, reject) => {
+                chan.on('close', () => resolve());
+                chan.on('exit', (exitCode: number | null, signalName?: string, didCoreDump?: boolean, description?: string) => {
+                    if (exitCode === 0) return resolve();
+
+                    void(didCoreDump);
+                    this.logger.error(`SSHExecServer.tcpConnect: error: exitCode=${exitCode}, signalName=${signalName}, description=${description}`);
+                    reject({ status: exitCode ?? (signalName ? 128 : 0) });
+                });
+            }),
+        };
     }
 
     public dispose() {
-        throw new Error("Method not implemented.");
+        this.fs.dispose();
+        // conn is closed in the resolver
     }
 }

--- a/src/execServer.ts
+++ b/src/execServer.ts
@@ -1,35 +1,87 @@
 import * as vscode from 'vscode';
+import { Log } from './common/logger';
+import { SFTPWrapper } from 'ssh2';
+import SSHConnection from './ssh/sshConnection';
 
-export class SSHExecServer implements vscode.ExecServer, vscode.Disposable {
-    fs: vscode.RemoteFileSystem;
-
-    public constructor() { }
-
-    public spawn(command: string, args: string[], options?: vscode.ExecServerSpawnOptions): Thenable<vscode.SpawnedCommand> {
-        throw new Error('Method not implemented.');
+export class SSHExecServerFileSystem implements vscode.RemoteFileSystem, vscode.Disposable {
+    public constructor(
+        private readonly sftp: SFTPWrapper,
+        private readonly logger: Log
+    ) {
     }
 
-    public spawnRemoteServerConnector?(command: string, args: string[], options?: vscode.ExecServerSpawnOptions): Thenable<vscode.RemoteServerConnector> {
-        throw new Error('Method not implemented.');
+    public stat(path: string): Thenable<vscode.FileStat> {
+        throw new Error("Method 'stat' not implemented.");
     }
 
-    public downloadCliExecutable?(buildTarget: vscode.CliBuild, command: string, args: string[], options?: vscode.ExecServerSpawnOptions): Thenable<vscode.ProcessExit> {
-        throw new Error('Method not implemented.');
+    public mkdirp(path: string): Thenable<void> {
+        throw new Error("Method 'mkdirp' not implemented.");
     }
 
-    public env(): Thenable<vscode.ExecEnvironment> {
-        throw new Error('Method not implemented.');
+    public rm(path: string): Thenable<void> {
+        throw new Error("Method 'rm' not implemented.");
     }
 
-    public kill(processId: number): Thenable<void> {
-        throw new Error('Method not implemented.');
+    public read(path: string): Thenable<vscode.ReadStream> {
+        throw new Error("Method 'read' not implemented.");
     }
 
-    public tcpConnect(host: string, port: number): Thenable<{ stream: vscode.WriteStream & vscode.ReadStream; done: Thenable<void> }> {
-        throw new Error('Method not implemented.');
+    public write(path: string): Thenable<{ stream: vscode.WriteStream; done: Thenable<void>; }> {
+        throw new Error("Method 'write' not implemented.");
+    }
+
+    public connect(path: string): Thenable<{ stream: vscode.WriteStream & vscode.ReadStream; done: Thenable<void>; }> {
+        throw new Error("Method 'connect' not implemented.");
+    }
+
+    public rename(fromPath: string, toPath: string): Thenable<void> {
+        throw new Error("Method 'rename' not implemented.");
+    }
+
+    public readdir(path: string): Thenable<vscode.DirectoryEntry[]> {
+        throw new Error("Method 'readdir' not implemented.");
     }
 
     public dispose() {
-        throw new Error('Method not implemented.');
+        throw new Error("Method 'dispose' not implemented.");
+    }
+}
+
+export class SSHExecServer implements vscode.ExecServer, vscode.Disposable {
+    fs: SSHExecServerFileSystem;
+
+    public constructor(
+        private readonly conn: SSHConnection,
+        private readonly logger: Log
+    ) {
+        this.fs = new SSHExecServerFileSystem(conn, logger);
+    }
+
+    public spawn(command: string, args: string[], options?: vscode.ExecServerSpawnOptions): Thenable<vscode.SpawnedCommand> {
+        throw new Error("Method not implemented.");
+    }
+
+    public spawnRemoteServerConnector?(command: string, args: string[], options?: vscode.ExecServerSpawnOptions): Thenable<vscode.RemoteServerConnector> {
+        throw new Error("Method not implemented.");
+    }
+
+    public downloadCliExecutable?(buildTarget: vscode.CliBuild, command: string, args: string[], options?: vscode.ExecServerSpawnOptions): Thenable<vscode.ProcessExit> {
+        throw new Error("Method not implemented.");
+    }
+
+    public env(): Thenable<vscode.ExecEnvironment> {
+        throw new Error("Method not implemented.");
+    }
+
+    public kill(processId: number): Thenable<void> {
+        throw new Error("Method not implemented.");
+    }
+
+    public tcpConnect(host: string, port: number): Thenable<{ stream: vscode.WriteStream & vscode.ReadStream; done: Thenable<void> }> {
+        throw new Error("Method not implemented.");
+    }
+
+    public dispose() {
+        throw new Error("Method not implemented.");
     }
 }

--- a/src/ssh/sshConnection.ts
+++ b/src/ssh/sshConnection.ts
@@ -80,6 +80,27 @@ export default class SSHConnection extends EventEmitter {
     }
 
     /**
+     * Get the underlying ssh2 Client for direct access (SFTP, raw channels).
+     */
+    getClient(): Client | null {
+        return this.sshConnection;
+    }
+
+    /**
+     * Exec a command and return the raw channel for streaming access.
+     */
+    execChannel(cmd: string, options: ExecOptions = {}): Promise<ClientChannel> {
+        return this.connect().then(() => {
+            return new Promise<ClientChannel>((resolve, reject) => {
+                this.sshConnection!.exec(cmd, options, (err, stream) => {
+                    if (err) {return reject(err);}
+                    resolve(stream);
+                });
+            });
+        });
+    }
+
+    /**
      * Get shell socket
      */
     shell(options: ShellOptions = {}): Promise<ClientChannel> {

--- a/src/ssh/sshConnection.ts
+++ b/src/ssh/sshConnection.ts
@@ -3,7 +3,7 @@
 import { EventEmitter } from 'events';
 import * as net from 'net';
 import * as fs from 'fs';
-import { Client, ClientChannel, ClientErrorExtensions, ExecOptions, ShellOptions, ConnectConfig } from 'ssh2';
+import { Client, ClientChannel, ClientErrorExtensions, ExecOptions, ShellOptions, ConnectConfig, SFTPWrapper } from 'ssh2';
 import { Server } from 'net';
 import socks from 'simple-socks';
 // eslint-disable-next-line no-duplicate-imports
@@ -372,6 +372,35 @@ export default class SSHConnection extends EventEmitter {
         }
 
         return Promise.resolve();
+    }
+
+    getClient(): Client {
+        if(!this.sshConnection) {
+            throw new Error('Not connected');
+        }
+
+        return this.sshConnection;
+    }
+
+    createSftp(): Promise<SFTPWrapper> {
+        const ssh = this.sshConnection;
+
+        if(!ssh) {
+            throw new Error('Not connected');
+        }
+
+        const sftp: Promise<SFTPWrapper> = new Promise((resolve, reject) => {
+            ssh.sftp((err: Error | undefined, sftp: SFTPWrapper) => {
+                if (err) {
+                    return reject(err);
+                }
+                else {
+                    resolve(sftp);
+                }
+            });
+        });
+
+        return sftp;
     }
 
     private createSshForwardTarget(destination: DestinationInfo, origin: OriginInfo, callback: ConnectionOptionsCallback) {

--- a/test/execServer.test.ts
+++ b/test/execServer.test.ts
@@ -1,0 +1,92 @@
+import { FileType } from 'vscode';
+import { describe, expect, it } from 'vitest';
+import { shellEscapeArg, shellEscaped, getFileType } from '../src/execServer';
+
+describe('shellEscapeArg', () => {
+	it('wraps simple string in single quotes', () => {
+		expect(shellEscapeArg('hello')).toBe("'hello'");
+	});
+
+	it('escapes single quotes', () => {
+		expect(shellEscapeArg("it's")).toBe("'it'\\''s'");
+	});
+
+	it('handles empty string', () => {
+		expect(shellEscapeArg('')).toBe("''");
+	});
+
+	it('handles multiple single quotes', () => {
+		expect(shellEscapeArg("a'b'c")).toBe("'a'\\''b'\\''c'");
+	});
+
+	it('preserves spaces and special chars inside quotes', () => {
+		expect(shellEscapeArg('hello world')).toBe("'hello world'");
+		expect(shellEscapeArg('$HOME')).toBe("'$HOME'");
+		expect(shellEscapeArg('a;rm -rf /')).toBe("'a;rm -rf /'");
+		expect(shellEscapeArg('`whoami`')).toBe("'`whoami`'");
+	});
+});
+
+describe('shellEscaped', () => {
+	it('escapes command and args', () => {
+		expect(shellEscaped('ls', ['-la', '/tmp'])).toBe("'ls' '-la' '/tmp'");
+	});
+
+	it('prepends cwd', () => {
+		expect(shellEscaped('ls', [], { cwd: '/home/user' })).toBe("cd '/home/user' && 'ls'");
+	});
+
+	it('prepends env vars', () => {
+		expect(shellEscaped('node', ['app.js'], { env: { FOO: 'bar', BAZ: 'qux' } }))
+			.toBe("FOO='bar' BAZ='qux' 'node' 'app.js'");
+	});
+
+	it('env: ordered after cd but before cmd', () => {
+		const result = shellEscaped('run', [], { cwd: '/app', env: { X: '1' } });
+		expect(result).toBe("cd '/app' && X='1' 'run'");
+	});
+
+	it('env: escapes values but not keys', () => {
+		expect(shellEscaped('cmd', [], { env: { PATH: "/usr/bin:/bin" } }))
+			.toBe("PATH='/usr/bin:/bin' 'cmd'");
+	});
+
+	it('env: rejects invalid keys', () => {
+		expect(() => shellEscaped('cmd', [], { env: { 'bad key': 'v' } })).toThrow('Bad env key');
+		expect(() => shellEscaped('cmd', [], { env: { '1start': 'v' } })).toThrow('Bad env key');
+		expect(() => shellEscaped('cmd', [], { env: { 'a;b': 'v' } })).toThrow('Bad env key');
+		expect(() => shellEscaped('cmd', [], { env: { '': 'v' } })).toThrow('Bad env key');
+	});
+
+	it('env: accepts valid keys', () => {
+		expect(() => shellEscaped('cmd', [], { env: { _FOO: 'v' } })).not.toThrow();
+		expect(() => shellEscaped('cmd', [], { env: { A_B_C: 'v' } })).not.toThrow();
+		expect(() => shellEscaped('cmd', [], { env: { x1: 'v' } })).not.toThrow();
+	});
+});
+
+describe('getFileType', () => {
+	it('identifies regular files', () => {
+		expect(getFileType(0o100644)).toBe(FileType.File);
+		expect(getFileType(0o100755)).toBe(FileType.File);
+	});
+
+	it('identifies directories', () => {
+		expect(getFileType(0o040755)).toBe(FileType.Directory);
+	});
+
+	it('identifies symbolic links', () => {
+		expect(getFileType(0o120777)).toBe(FileType.SymbolicLink);
+	});
+
+	it('does not misclassify regular files as symlinks', () => {
+		expect(getFileType(0o100644)).not.toBe(FileType.SymbolicLink);
+	});
+
+	it('returns Unknown for other types', () => {
+		expect(getFileType(0o060660)).toBe(FileType.Unknown); // block device
+		expect(getFileType(0o020666)).toBe(FileType.Unknown); // char device
+		expect(getFileType(0o010644)).toBe(FileType.Unknown); // fifo
+		expect(getFileType(0o140755)).toBe(FileType.Unknown); // socket
+	});
+});

--- a/test/mocks/vscode.ts
+++ b/test/mocks/vscode.ts
@@ -89,6 +89,13 @@ const workspace = {
     registerResourceLabelFormatter: vi.fn()
 };
 
+enum FileType {
+    Unknown = 0,
+    File = 1,
+    Directory = 2,
+    SymbolicLink = 64,
+}
+
 export {
     commands,
     env,
@@ -97,6 +104,7 @@ export {
     RemoteAuthorityResolverContext,
     RemoteAuthorityResolverError,
     ResolvedAuthority,
+    FileType,
     window,
     version,
     workspace,


### PR DESCRIPTION
I have a basic devcontainer extension [here](https://github.com/MythreyaK/open-remote-devcontainer), and wanted to get devcontainer on a remote ssh machine working. There is a lot of work left to be done on the devcontainer parts itself, but I was hoping we can start planning towards chaining. 

The corresponding branch on the devcontainer side is [here](https://github.com/MythreyaK/open-remote-devcontainer/tree/exec-chaining). Install both, and open a workspace with a devcontainer configuration. You should be able to "reopen in container". 

Note: Updated after a rewrite of both this PR and the supporting extension. 