### PR TITLE
fix: use base64 encoding for install script to support csh/tcsh login shells

### DIFF
--- a/src/serverSetup.ts
+++ b/src/serverSetup.ts
@@ -210,9 +210,10 @@ export async function installCodeServer(
         const installServerScript = generateBashInstallScript(installOptions);
 
         logger.trace('Server install command:', installServerScript);
-        // Fish shell does not support heredoc so let's workaround it using -c option,
-        // also replace single quotes (') within the script with ('\'') as there's no quoting within single quotes, see https://unix.stackexchange.com/a/24676
-        commandOutput = await conn.exec(`bash -lc '${installServerScript.replace(/'/g, `'\\''`)}'`);
+        // Use base64 encoding to avoid shell quoting issues across different login shells (bash, csh, tcsh, fish).
+        // csh cannot handle multi-line strings inside single quotes with -c, so piping via base64 is the most portable approach.
+        const base64Script = Buffer.from(installServerScript).toString('base64');
+        commandOutput = await conn.exec(`echo ${base64Script} | base64 -d | bash -l`);
     }
 
     if (commandOutput.stderr) {


### PR DESCRIPTION
csh/tcsh cannot handle multi-line strings inside single quotes when passed via SSH exec channels. This caused the server install script to fail with 'Unmatched quote' errors for users whose remote login shell is csh or tcsh.
    
Replace the bash -lc '...' approach with base64 encoding the script and piping it to bash, which is agnostic to the intermediary shell.
    
Use a fallback from base64 -d (Linux/macOS) to base64 -D (OpenBSD) for maximum portability across platforms.