### PR TITLE
feat: use official simple-socks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
 				"@zokugun/is-it-type": "0.8.1",
 				"glob": "13.0.6",
 				"semver": "7.8.5",
-				"simple-socks": "git+https://github.com/jeanp413/simple-socks#main",
+				"simple-socks": "3.6.0",
 				"socks": "2.8.9",
 				"ssh-config": "5.2.0",
 				"ssh2": "git+https://github.com/jeanp413/ssh2#master"
@@ -324,18 +324,6 @@
 			},
 			"engines": {
 				"node": ">=6.0.0"
-			}
-		},
-		"node_modules/@babel/runtime-corejs3": {
-			"version": "7.29.7",
-			"resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.29.7.tgz",
-			"integrity": "sha512-ppj9ouYku+RX0ljtgZd+KMO5mkM2bCqg8H2PYAFWnLsHEIKIdRojqbJ2i3eVHrisuxy7nOFCmngTDdWtUCdXUQ==",
-			"license": "MIT",
-			"dependencies": {
-				"core-js-pure": "^3.48.0"
-			},
-			"engines": {
-				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/types": {
@@ -3896,9 +3884,9 @@
 			"optional": true
 		},
 		"node_modules/baseline-browser-mapping": {
-			"version": "2.11.1",
-			"resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.1.tgz",
-			"integrity": "sha512-HYXq73DDpCtNzOmrFsm9eSwCvWCql0RzqjpDzXN9EadiLJ4DNat0nsZ/Bzmy+Ud12mb4/zKDY0cQ805ZzN+i0A==",
+			"version": "2.11.3",
+			"resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.3.tgz",
+			"integrity": "sha512-sbT0Ui/CZwyAyy7icT1Gw5P1LKRlFaHwaF6tDCW5YHq2X5SeeZFphBuIagopSfwSSZq3sQcbmEL072yphxm7ew==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {
@@ -4688,17 +4676,6 @@
 			"integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/core-js-pure": {
-			"version": "3.49.0",
-			"resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.49.0.tgz",
-			"integrity": "sha512-XM4RFka59xATyJv/cS3O3Kml72hQXUeGRuuTmMYFxwzc9/7C8OYTaIR/Ji+Yt8DXzsFLNhat15cE/JP15HrCgw==",
-			"hasInstallScript": true,
-			"license": "MIT",
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/core-js"
-			}
 		},
 		"node_modules/cosmiconfig": {
 			"version": "9.0.2",
@@ -10138,12 +10115,15 @@
 			}
 		},
 		"node_modules/simple-socks": {
-			"version": "2.2.2",
-			"resolved": "git+ssh://git@github.com/jeanp413/simple-socks.git#2ac739301a82d6baff04804ed494436a026acb60",
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/simple-socks/-/simple-socks-3.6.0.tgz",
+			"integrity": "sha512-fk2tjCKSPDW3KM2QzNCN85K3DlI+l95qREFEm6LKYWWnzlut+cfxTXmJIZw+5fst9MUmpvCnVc0U5/YZln0sbA==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/runtime-corejs3": "^7.16.8",
 				"binary": "^0.3.0"
+			},
+			"engines": {
+				"node": ">=16.0"
 			}
 		},
 		"node_modules/sirv": {
@@ -10761,9 +10741,9 @@
 			}
 		},
 		"node_modules/thingies": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/thingies/-/thingies-2.6.0.tgz",
-			"integrity": "sha512-rMHRjmlFLM1R96UYPvpmnc3LYtdFrT33JIB7L9hetGue1qAPfn1N2LJeEjxUSidu1Iku+haLZXDuEXUHNGO/lg==",
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/thingies/-/thingies-2.6.1.tgz",
+			"integrity": "sha512-cV/CMGTK3M4MlnJ/0At6ismOw/A0EEniDNScajjz/Br3c1sqE72YD01rGpPTKwd27wAxI5Pr+6+0w8yofzFRYw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -11936,9 +11916,9 @@
 			}
 		},
 		"node_modules/yoctocolors": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.2.tgz",
-			"integrity": "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.2.0.tgz",
+			"integrity": "sha512-xYqdZFUK/VYazNl/oCDYN+3WloWQwMfZxBoiNt6qNyk+xfOdi598muWE42rNZFp1kNOiqW936q5RhUdnpqElSg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
 		"@zokugun/is-it-type": "0.8.1",
 		"glob": "13.0.6",
 		"semver": "7.8.5",
-		"simple-socks": "git+https://github.com/jeanp413/simple-socks#main",
+		"simple-socks": "3.6.0",
 		"socks": "2.8.9",
 		"ssh-config": "5.2.0",
 		"ssh2": "git+https://github.com/jeanp413/ssh2#master"

--- a/src/ssh/sshConnection.ts
+++ b/src/ssh/sshConnection.ts
@@ -6,6 +6,7 @@ import * as fs from 'fs';
 import { Client, ClientChannel, ClientErrorExtensions, ExecOptions, ShellOptions, ConnectConfig } from 'ssh2';
 import { Server } from 'net';
 import socks from 'simple-socks';
+// eslint-disable-next-line no-duplicate-imports
 import type { DestinationInfo, OriginInfo, ConnectionOptionsCallback } from 'simple-socks';
 import { isString } from '@zokugun/is-it-type';
 
@@ -374,10 +375,10 @@ export default class SSHConnection extends EventEmitter {
     }
 
     private createSshForwardTarget(destination: DestinationInfo, origin: OriginInfo, callback: ConnectionOptionsCallback) {
-        const ssh = this.sshConnection
+        const ssh = this.sshConnection;
 
         if(!ssh) {
-            return callback(new Error('Not connected'))
+            return callback(new Error('Not connected'));
         }
 
         const forwarder = net.createServer((localSocket) => {
@@ -412,7 +413,7 @@ export default class SSHConnection extends EventEmitter {
             const address = forwarder.address();
 
             if(address === null || isString(address)) {
-                return callback(new Error(`Invalid address: ${address}`))
+                return callback(new Error(`Invalid address: ${address}`));
             }
 
             callback(null, {

--- a/src/ssh/sshConnection.ts
+++ b/src/ssh/sshConnection.ts
@@ -3,10 +3,11 @@
 import { EventEmitter } from 'events';
 import * as net from 'net';
 import * as fs from 'fs';
-import * as stream from 'stream';
 import { Client, ClientChannel, ClientErrorExtensions, ExecOptions, ShellOptions, ConnectConfig } from 'ssh2';
 import { Server } from 'net';
-import { SocksConnectionInfo, createServer as createSocksServer } from 'simple-socks';
+import socks from 'simple-socks';
+import type { DestinationInfo, OriginInfo, ConnectionOptionsCallback } from 'simple-socks';
+import { isString } from '@zokugun/is-it-type';
 
 export interface SSHConnectConfig extends ConnectConfig {
     /** Optional Unique ID attached to ssh connection. */
@@ -282,23 +283,20 @@ export default class SSHConnection extends EventEmitter {
             return new Promise((resolve, reject) => {
                 let server: net.Server;
                 if (SSHTunnelConfig.socks) {
-                    server = createSocksServer({
-                        connectionFilter: (destination: SocksConnectionInfo, origin: SocksConnectionInfo, callback: (err?: unknown, dest?: stream.Duplex) => void) => {
-                            this.connect().then(() => {
-                                this.sshConnection!.forwardOut(
-                                    origin.address,
-                                    origin.port,
-                                    destination.address,
-                                    destination.port,
-                                    (err, stream) => {
-                                        if (err) {
-                                            this.emit(SSHConstants.CHANNEL.TUNNEL, SSHConstants.STATUS.DISCONNECT, { SSHTunnelConfig: SSHTunnelConfig, err: err });
-                                            return callback(err);
-                                        }
-                                        return callback(null, stream);
-                                    });
+                    server = socks.createServer({
+                        connectionOptions: (destination, origin, defaults, callback) => {
+                            this.createSshForwardTarget(destination, origin, (err, target) => {
+                                if (err) {
+                                    this.emit(SSHConstants.CHANNEL.TUNNEL, SSHConstants.STATUS.DISCONNECT, { SSHTunnelConfig: SSHTunnelConfig, err: err });
+                                    return callback(err);
+                                }
+
+                                return callback(null, {
+                                    ...defaults,
+                                    ...target,
+                                });
                             });
-                        }
+                        },
                     }).on('proxyError', (err: unknown) => {
                         this.emit(SSHConstants.CHANNEL.TUNNEL, SSHConstants.STATUS.DISCONNECT, { SSHTunnelConfig: SSHTunnelConfig, err: err });
                     });
@@ -373,5 +371,54 @@ export default class SSHConnection extends EventEmitter {
         }
 
         return Promise.resolve();
+    }
+
+    private createSshForwardTarget(destination: DestinationInfo, origin: OriginInfo, callback: ConnectionOptionsCallback) {
+        const ssh = this.sshConnection
+
+        if(!ssh) {
+            return callback(new Error('Not connected'))
+        }
+
+        const forwarder = net.createServer((localSocket) => {
+            // This listener is for one SOCKS request only.
+            forwarder.close();
+
+            ssh.forwardOut(
+                origin.address,
+                origin.port,
+                destination.address,
+                destination.port,
+                (err, sshStream) => {
+                    if (err) {
+                        localSocket.destroy(err);
+                        return;
+                    }
+
+                    localSocket.pipe(sshStream);
+                    sshStream.pipe(localSocket);
+
+                    localSocket.once('close', () => sshStream.destroy());
+                    localSocket.once('error', () => sshStream.destroy());
+                    sshStream.once('close', () => localSocket.destroy());
+                    sshStream.once('error', () => localSocket.destroy());
+                },
+            );
+        });
+
+        forwarder.once('error', callback);
+
+        forwarder.listen(0, '127.0.0.1', () => {
+            const address = forwarder.address();
+
+            if(address === null || isString(address)) {
+                return callback(new Error(`Invalid address: ${address}`))
+            }
+
+            callback(null, {
+                host: address.address,
+                port: address.port,
+            });
+        });
     }
 }

--- a/src/utils/sanitize-extension-ids.ts
+++ b/src/utils/sanitize-extension-ids.ts
@@ -1,5 +1,5 @@
 const ID_REGEX = /^[\w-]+\.[\w-]+$/;
 
 export function sanitizeExtensionIds(ids: string[]): string[] {
-    return ids.filter((id) => ID_REGEX.test(id))
+    return ids.filter((id) => ID_REGEX.test(id));
 }


### PR DESCRIPTION
The PR is switching back to the official `simple-socks` lib due to:
- added connectionOptions support: https://github.com/brozeph/simple-socks/pull/77
- removal of `@babel/runtime-corejs3` since 4 years ago causing issues like https://github.com/jeanp413/open-remote-ssh/issues/308