### PR TITLE
fix: use a fixed file descriptor for the install lock

### DIFF
--- a/src/scripts/server-setup.sh
+++ b/src/scripts/server-setup.sh
@@ -46,7 +46,10 @@ print_install_results_and_exit() {
 LOCKFILE="$TMP_DIR/server_install.lock"
 
 if command -v flock >/dev/null 2>&1; then
-  exec {FD}<>"$LOCKFILE"
+  # Automatic file descriptor allocation ({FD}) requires bash >= 4.1,
+  # and macOS still ships bash 3.2, so use a fixed descriptor instead.
+  FD=9
+  exec 9<>"$LOCKFILE"
 
   if flock --help 2>&1 | grep -q -- '-w'; then
     # wait 30s to acquire lock, otherwise fail


### PR DESCRIPTION
`exec {FD}<>` requires bash >= 4.1. macOS still ships bash 3.2, and the install script is piped to `bash -l`, so on a macOS remote the lock setup fails with:

```
bash: line 49: exec: {FD}: not found
```

The script then prints none of the expected markers and the connection ends as `Failed parsing install script output`.

It only triggers when `flock` is present on the remote — stock macOS has none, so the `else` branch is taken and everything works. Installing it (e.g. via Homebrew) is enough to hit it, which is probably why it has gone unnoticed.

A fixed descriptor keeps every existing `$FD` reference working and behaves the same on old and new bash.

Verified on two remotes, running the lock section verbatim:

| remote | bash | `exec {FD}<>` | `FD=9` |
| --- | --- | --- | --- |
| macOS (Homebrew flock) | 3.2.57 | `exec: {FD}: not found` | lock acquired |
| Linux (`/usr/bin/flock`) | 5.2.21 | lock acquired | lock acquired |

End to end, the same macOS remote fails to connect before the change and connects after it. Present since #285, so v0.2.0 is affected too.
