### PR TITLE
ci: correctly get the latest version

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Get Version
         run: |
           # Get the latest tag
-          LATEST_TAG=$(git tag --sort=-v:refname | head -n1)
+          LATEST_TAG=$(git tag | tr - \~ | sort -rV | tr \~ - | head -n1)
 
           if [ -z "$LATEST_TAG" ]; then
             echo "No tags found in the repository"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Get Version
         run: |
           # Get the latest tag
-          LATEST_TAG=$(git tag --sort=-v:refname | head -n1)
+          LATEST_TAG=$(git tag | tr - \~ | sort -rV | tr \~ - | head -n1)
 
           if [ -z "$LATEST_TAG" ]; then
             echo "No tags found in the repository"


### PR DESCRIPTION
- `git tag --sort=-v:refname` gives incorrectly:
```
v0.3.1-beta.3
v0.3.1-beta.2
v0.3.1-beta.1
v0.3.1
v0.3.0
```

- `git tag | tr - \~ | sort -rV | tr \~ -` gives correctly:
```
v0.3.1
v0.3.1-beta.3
v0.3.1-beta.2
v0.3.1-beta.1
v0.3.0
```